### PR TITLE
chore: add CI and CD workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  megalinter:
+  Magalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
     permissions:
@@ -53,7 +53,7 @@ jobs:
             mega-linter.log
 
   Project-Build:
-    needs: megalinter
+    needs: Magalinter
     runs-on: ubuntu-latest
 
     steps:
@@ -81,6 +81,7 @@ jobs:
 
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
+        if: ${{ contains(github.ref, 'ref/tags/') }}
         with:
           build-args: |
             JAR_FILE=build/libs/*.jar
@@ -90,3 +91,48 @@ jobs:
           tags: |
             commongrondproject/backend:${{ github.ref_name }}
             commongrondproject/backend:${{ github.sha }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        if: ${{ !(contains(github.ref, 'ref/tags/')) }}
+        with:
+          build-args: |
+            JAR_FILE=build/libs/*.jar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            commongrondproject/backend:dev-${{ github.ref_name }}
+            commongrondproject/backend:${{ github.sha }}
+
+  Deploy:
+    needs: [Project-Build, Magalinter]
+    runs-on: [self-hosted, linux]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo '${{ secrets.DEV_DEPLOY_PRIVATE_KEY }}' >> ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Deploy Dev
+        if: ${{ !(contains(github.ref, 'ref/tags/')) }}
+        run: |
+          export MODE='Dev'
+          export ENV='${{ github.event.number }}'
+          export NAME='dev-${{ github.ref_name }}'
+          ssh -o SendEnv=MODE -o SendEnv=NAME -o SendEnv=ENV -i ~/.ssh/id_rsa gh-runner@192.168.80.21
+
+      - name: Deploy Stage
+        if: ${{ (contains(github.ref, 'ref/tags/')) }}
+        run: |
+          export MODE='Stage'
+          export NAME='dev-${{ github.ref_name }}'
+          ssh -o SendEnv=MODE -o SendEnv=NAME -i ~/.ssh/id_rsa gh-runner@192.168.80.21
+
+      - name: Clear up
+        run: rm ~/.ssh/id_rsa

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+    tags:
+      - v*
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -71,6 +70,8 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --build-cache
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
             megalinter-reports
             mega-linter.log
 
-  project-build:
+  Project-Build:
     needs: megalinter
     runs-on: ubuntu-latest
 
@@ -71,5 +71,21 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --build-cache
 
-      - name: Build Docker image
-        run: docker build --build-arg JAR_FILE=build/libs/*.jar -t springio/gs-spring-boot-docker .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            JAR_FILE=build/libs/*.jar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            commongrondproject/backend:${{ github.ref_name }}
+            commongrondproject/backend:${{ github.sha }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,9 +101,10 @@ jobs:
           echo '${{ secrets.DEV_DEPLOY_PRIVATE_KEY }}' >> ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
-#      - name: SSH to Dev
-#        run: |
-#          ssh -i ~/.ssh/id_rsa gh-runner@192.168.80.21 'docker run -d --name pr-${{ github.event.number }} -p ${{ github.event.number }}00 commongroundproject/backend:pr-${{ github.event.number }}'
-#
-#      - name: Clear up
-#        run: rm -f ~/.ssh/id_rsa
+      - name: Deploy image
+        run: |
+          export ENV='${{ github.event.number }}'
+          ssh -o SendEnv=ENV -i ~/.ssh/id_rsa gh-runner@192.168.80.21
+
+      - name: Clear up
+        run: rm ~/.ssh/id_rsa

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  megalinter:
+  Magalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
     permissions:
@@ -87,7 +87,7 @@ jobs:
             commongroundproject/backend:${{ github.sha }}
           context: .
 
-  Deploy:
+  Deploy-Snapshot:
     needs: Project-Build
     runs-on: [self-hosted, linux]
 
@@ -103,8 +103,9 @@ jobs:
 
       - name: Deploy image
         run: |
+          export MODE='Snapshot'
           export ENV='${{ github.event.number }}'
-          ssh -o SendEnv=ENV -i ~/.ssh/id_rsa gh-runner@192.168.80.21
+          ssh -o SendEnv=MODE -o SendEnv=ENV -i ~/.ssh/id_rsa gh-runner@192.168.80.21
 
       - name: Clear up
         run: rm ~/.ssh/id_rsa

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -70,6 +67,8 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --build-cache
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -80,11 +79,31 @@ jobs:
       - name: Build and Push Docker image
         uses: docker/build-push-action@v6
         with:
-          build-args: |
-            JAR_FILE=build/libs/*.jar
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
           tags: |
-            commongrondproject/backend:${{ github.ref_name }}
-            commongrondproject/backend:${{ github.sha }}
+            commongroundproject/backend:pr-${{ github.event.number }}
+            commongroundproject/backend:${{ github.sha }}
+          context: .
+
+  Deploy:
+    needs: Project-Build
+    runs-on: [self-hosted, linux]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo '${{ secrets.DEV_DEPLOY_PRIVATE_KEY }}' >> ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+#      - name: SSH to Dev
+#        run: |
+#          ssh -i ~/.ssh/id_rsa gh-runner@192.168.80.21 'docker run -d --name pr-${{ github.event.number }} -p ${{ github.event.number }}00 commongroundproject/backend:pr-${{ github.event.number }}'
+#
+#      - name: Clear up
+#        run: rm -f ~/.ssh/id_rsa

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,7 +53,7 @@ jobs:
             megalinter-reports
             mega-linter.log
 
-  project-build:
+  Project-Build:
     runs-on: ubuntu-latest
 
     steps:
@@ -70,5 +70,21 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --build-cache
 
-      - name: Build Docker image
-        run: docker build --build-arg JAR_FILE=build/libs/*.jar -t springio/gs-spring-boot-docker .
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          build-args: |
+            JAR_FILE=build/libs/*.jar
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            commongrondproject/backend:${{ github.ref_name }}
+            commongrondproject/backend:${{ github.sha }}


### PR DESCRIPTION
# CI/CD Workflow
## Deploy Snapshot
When a PR is created, build a new Docker image with `pr-<pull_request_number>` as the tag, deploy it in a container where the port is `1000 + <pull_request_number>` on the dev machine, and remove the previous container for this PR.

## Deploy Dev
When the PR merges into the main branch, build a new Docker image with `dev-<ref_name>` as the tag, deploy it in a container where the port is `8080` on the dev machine, and remove the container for this PR as well as the previous dev container.

## Deploy Stage
When the main branch is tagged with `stage`, build a new Docker image with `ref_name` as the tag, and deploy it in a container where the port is `8081` on the dev machine.

# Machine Configuration
## SSH Configuration
Add the following lines in the `sshd_config` file on the dev machine.
Adding these ensures that these environment variables can be passed to the dev machine.
```sh
AcceptEnv MODE
AcceptEnv NAME
AcceptEnv ENV
``` 
##Deploying Shell Script
Add the file `~/deploy.sh` under the `gh-runner` user to execute the deployment commands when the self-hosted runner logs into the dev machine via SSH.
