### PR TITLE
chore: Setup Google OAuth2 login and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/application-dev.properties
 
 ### OS-specific files ###
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+dev:
+	./gradlew bootRun --args='--spring.profiles.active=dev'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# backend
+# Backend
+
+## Google OAuth2 Login in Development
+
+1. Create an `application-dev.properties` file in the `src/main/resources` directory.
+2. Copy other configurations from `application.properties`, then add the following configuration to the `application-dev.properties` file:
+
+    ```properties
+    spring.security.oauth2.client.registration.google.clientId=your-google-client-id
+    spring.security.oauth2.client.registration.google.clientSecret=your-google-client-secret
+    ```
+
+3. To start the application with the `dev` profile, run the following command:
+
+    ```sh
+    make dev
+    ```
+
+    Alternatively, you can use the following command:
+
+    ```sh
+    ./gradlew bootRun --args='--spring.profiles.active=dev'
+    ```
+
+This will configure your Spring Boot application to use Google OAuth2 for login during development.

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator:3.3.4'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'


### PR DESCRIPTION
## Environment-Specific OAuth2 Configuration:

Added **application-dev.properties** to **.gitignore** to prevent committing environment-specific configurations.
Updated **README.md** with instructions for setting up Google OAuth2 login in development. This includes setting clientId and clientSecret in application-dev.properties.

## Makefile:

Introduced a **Makefile** with a dev command to start the application using the dev profile. This simplifies running the application with `./gradlew bootRun --args='--spring.profiles.active=dev'.`
```sh
make dev
```

## Dependency Update:

Updated **build.gradle** to include spring-boot-starter-oauth2-client, allowing Google OAuth2 integration for user authentication in the dev environment.