### PR TITLE
Add instructions for running linter locally to readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,10 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 dev:
 	./gradlew bootRun --args='--spring.profiles.active=dev'
+
+test:
+	./gradlew test
+
+lint:
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:rw -v $(ROOT_DIR):/tmp/lint:rw oxsecurity/megalinter:v8

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@
 
 ### Linting
 
-This project uses [MegaLinter](https://nvuillam.github.io/megalinter) to lint the codebase. To run the linter, use the
+This project uses [MegaLinter](https://megalinter.io/) to lint the codebase. To run the linter, use the
 following command:
 
 ```sh
 make lint
 ```
 
-It will start a docker container and run the linter on the codebase.
+This command will start a Docker container to run the linter against the codebase.
 
 ### Testing
 
-To run the tests, use the following command:
+To execute tests, use the command below:
 
 ```sh
 make test

--- a/README.md
+++ b/README.md
@@ -1,25 +1,51 @@
 # Backend
 
-## Google OAuth2 Login in Development
+## Development
+
+### Linting
+
+This project uses [MegaLinter](https://nvuillam.github.io/megalinter) to lint the codebase. To run the linter, use the
+following command:
+
+```sh
+make lint
+```
+
+It will start a docker container and run the linter on the codebase.
+
+### Testing
+
+To run the tests, use the following command:
+
+```sh
+make test
+```
+
+### Running the Application
+
+#### Configuration
+
+Google OAuth2 Configuration
 
 1. Create an `application-dev.properties` file in the `src/main/resources` directory.
-2. Copy other configurations from `application.properties`, then add the following configuration to the `application-dev.properties` file:
+2. Copy other configurations from `application.properties`, then add the following configuration to the
+   `application-dev.properties` file:
 
-    ```properties
-    spring.security.oauth2.client.registration.google.clientId=your-google-client-id
-    spring.security.oauth2.client.registration.google.clientSecret=your-google-client-secret
-    ```
+```properties
+spring.security.oauth2.client.registration.google.clientId=your-google-client-id
+spring.security.oauth2.client.registration.google.clientSecret=your-google-client-secret
+```
 
-3. To start the application with the `dev` profile, run the following command:
+To start the application with the `dev` profile, run the following command:
 
-    ```sh
-    make dev
-    ```
+```sh
+make dev
+```
 
-    Alternatively, you can use the following command:
+Alternatively, you can use the following command:
 
-    ```sh
-    ./gradlew bootRun --args='--spring.profiles.active=dev'
-    ```
+```sh
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
 
 This will configure your Spring Boot application to use Google OAuth2 for login during development.


### PR DESCRIPTION
## Type of changes
Document

## Purpose
- Add description to the README for executing the linter and running unit tests
- Add command to makefile to simplify lint and test

## Additional information
- Use `make lint` to execute linter
- Use `make test` to execute testing