### PR TITLE
Fix the content link does not return the relative position of fact list

### DIFF
--- a/src/main/java/tw/commonground/backend/service/issue/dto/IssueMapper.java
+++ b/src/main/java/tw/commonground/backend/service/issue/dto/IssueMapper.java
@@ -4,6 +4,8 @@ import tw.commonground.backend.service.fact.dto.FactMapper;
 import tw.commonground.backend.service.fact.entity.FactEntity;
 import tw.commonground.backend.service.issue.entity.IssueEntity;
 import tw.commonground.backend.service.issue.entity.SimpleIssueEntity;
+import tw.commonground.backend.shared.content.ContentContainFact;
+import tw.commonground.backend.shared.content.ContentContainFactParser;
 
 import java.util.List;
 
@@ -13,13 +15,17 @@ public final class IssueMapper {
     }
 
     public static IssueResponse toResponse(IssueEntity entity, List<FactEntity> factEntities) {
+
+        ContentContainFact insight = ContentContainFactParser.separateContentAndFacts(entity.getInsight(),
+                factEntities.stream().map(FactEntity::getId).toList());
+
         return IssueResponse.builder()
                 .id(entity.getId().toString())
                 .createAt(entity.getCreateAt())
                 .updatedAt(entity.getUpdatedAt())
                 .title(entity.getTitle())
                 .description(entity.getDescription())
-                .insight(entity.getInsight())
+                .insight(insight.getText())
                 .authorId(entity.getAuthorId())
                 .authorName(entity.getAuthorName())
                 .authorAvatar(entity.getAuthorAvatar())

--- a/src/main/java/tw/commonground/backend/service/viewpoint/dto/ViewpointMapper.java
+++ b/src/main/java/tw/commonground/backend/service/viewpoint/dto/ViewpointMapper.java
@@ -6,6 +6,8 @@ import tw.commonground.backend.service.fact.entity.FactEntity;
 import tw.commonground.backend.service.viewpoint.entity.Reaction;
 import tw.commonground.backend.service.viewpoint.entity.ViewpointEntity;
 import tw.commonground.backend.service.viewpoint.entity.ViewpointReactionEntity;
+import tw.commonground.backend.shared.content.ContentContainFact;
+import tw.commonground.backend.shared.content.ContentContainFactParser;
 
 import java.util.List;
 
@@ -26,12 +28,15 @@ public final class ViewpointMapper {
     public static ViewpointResponse toResponse(ViewpointEntity viewpointEntity, Reaction reaction,
                                                List<FactEntity> factEntities) {
 
+        ContentContainFact content = ContentContainFactParser.separateContentAndFacts(viewpointEntity.getContent(),
+                factEntities.stream().map(FactEntity::getId).toList());
+
         return ViewpointResponse.builder()
                 .id(viewpointEntity.getId())
                 .createdAt(viewpointEntity.getCreatedAt())
                 .updatedAt(viewpointEntity.getUpdatedAt())
                 .title(viewpointEntity.getTitle())
-                .content(viewpointEntity.getContent())
+                .content(content.getText())
                 .authorId(viewpointEntity.getAuthorId())
                 .authorName(viewpointEntity.getAuthorName())
                 .authorAvatar(viewpointEntity.getAuthorAvatar())

--- a/src/main/java/tw/commonground/backend/shared/content/ContentContainFactParser.java
+++ b/src/main/java/tw/commonground/backend/shared/content/ContentContainFactParser.java
@@ -80,4 +80,35 @@ public final class ContentContainFactParser {
 
         return contentContainFact;
     }
+
+    public static ContentContainFact separateContentAndFacts(String text, List<UUID> existingFacts) {
+        StringBuilder replacedText = new StringBuilder();
+
+        Matcher matcher = CONTENT_LINK_PATTERN.matcher(text);
+        List<UUID> uuids = new ArrayList<>(existingFacts);
+        while (matcher.find()) {
+            String linkText = matcher.group(1);
+            String linkPositions = matcher.group(2);
+
+            List<Integer> positions = new ArrayList<>();
+            for (String uid : linkPositions.split(",")) {
+                uid = uid.trim();
+                UUID uuid = UUID.fromString(uid);
+                positions.add(uuids.indexOf(uuid));
+            }
+
+            String newLink = "[" + linkText + "]("
+                    + String.join(",", positions.stream().map(Object::toString).toList()) + ")";
+            matcher.appendReplacement(replacedText, newLink);
+        }
+
+        matcher.appendTail(replacedText);
+
+        ContentContainFact contentContainFact = new ContentContainFact();
+        contentContainFact.setText(replacedText.toString());
+        contentContainFact.setFacts(uuids);
+
+        return contentContainFact;
+    }
 }
+


### PR DESCRIPTION
## Type of Changes
Fix

## Purpose
- Add the `separateContentAndFacts` method in `ContentContainFactParser` to handle parsing operations which include transforming UUIDs into index positions for processing links within text content.
- Let content link return the relative position of fact list.