### PR TITLE
Add unit testing for jwt package

### DIFF
--- a/src/main/java/tw/commonground/backend/configuration/UtilityConfiguration.java
+++ b/src/main/java/tw/commonground/backend/configuration/UtilityConfiguration.java
@@ -1,0 +1,14 @@
+package tw.commonground.backend.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class UtilityConfiguration {
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/jwt/JwtService.java
+++ b/src/main/java/tw/commonground/backend/service/jwt/JwtService.java
@@ -9,6 +9,7 @@ import tw.commonground.backend.service.jwt.entity.RefreshTokenRepository;
 import tw.commonground.backend.service.jwt.exception.RefreshTokenInvalidException;
 import tw.commonground.backend.service.user.entity.FullUserEntity;
 
+import java.time.Clock;
 import java.util.UUID;
 
 @Service
@@ -18,7 +19,10 @@ public class JwtService {
 
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public JwtService(JwtAccessUtil jwtAccessUtil, RefreshTokenRepository refreshTokenRepository) {
+    private final Clock clock;
+
+    public JwtService(Clock clock, JwtAccessUtil jwtAccessUtil, RefreshTokenRepository refreshTokenRepository) {
+        this.clock = clock;
         this.jwtAccessUtil = jwtAccessUtil;
         this.refreshTokenRepository = refreshTokenRepository;
 
@@ -32,7 +36,7 @@ public class JwtService {
     public RefreshTokenResponse generateTokens(FullUserEntity fullUserEntity) {
         String accessToken = jwtAccessUtil.generateAccessToken(fullUserEntity);
         RefreshTokenEntity refreshToken = jwtAccessUtil.generateRefreshToken(fullUserEntity);
-        Long expirationTime = System.currentTimeMillis() + jwtAccessUtil.getRefreshTokenExpirationMillis();
+        Long expirationTime = clock.millis() + jwtAccessUtil.getRefreshTokenExpirationMillis();
 
         return new RefreshTokenResponse(refreshToken.getId().toString(), expirationTime, accessToken);
     }
@@ -40,7 +44,7 @@ public class JwtService {
     public RefreshTokenResponse refreshToken(UUID refreshToken) {
         RefreshTokenProjection refreshTokenProjection = refreshTokenRepository
                 .findByIdAndIsActiveAndExpirationTimeAfter(refreshToken,
-                        true, System.currentTimeMillis()).orElseThrow(RefreshTokenInvalidException::new);
+                        true, clock.millis()).orElseThrow(RefreshTokenInvalidException::new);
 
         String accessToken = jwtAccessUtil.generateAccessToken(refreshTokenProjection.getUser());
         RefreshTokenEntity newRefreshToken = jwtAccessUtil.generateRefreshToken(refreshTokenProjection.getUser());
@@ -54,6 +58,6 @@ public class JwtService {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void rotateRefreshTokens() {
-        refreshTokenRepository.deleteAllByExpirationTimeBefore(System.currentTimeMillis());
+        refreshTokenRepository.deleteAllByExpirationTimeBefore(clock.millis());
     }
 }

--- a/src/main/java/tw/commonground/backend/service/jwt/entity/RefreshTokenProjectionImpl.java
+++ b/src/main/java/tw/commonground/backend/service/jwt/entity/RefreshTokenProjectionImpl.java
@@ -1,0 +1,14 @@
+package tw.commonground.backend.service.jwt.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import tw.commonground.backend.service.user.entity.FullUserEntity;
+
+@Getter
+@Setter
+public class RefreshTokenProjectionImpl implements RefreshTokenProjection {
+    private String id;
+    private String expirationTime;
+    private String isActive;
+    private FullUserEntity user;
+}

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -71,15 +71,13 @@ class JwtAccessUtilTest {
     @Test
     void testVerifyAccessToken_idIsNotNull_doesNotCallFetchEntityId() {
         FullUserEntity user = createUser();
-
         String token = jwtAccessUtil.generateAccessToken(user);
         JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
         ReflectionTestUtils.setField(jwtUserDetails, "id", 1L);
 
-        jwtUserDetails.getId();
+        assertThat(jwtUserDetails.getId()).isEqualTo(1L);
 
         verify(userRepository, Mockito.never()).getIdByUid(user.getUuid());
-        assertThat(jwtUserDetails.getId()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -1,0 +1,78 @@
+package tw.commonground.backend.service.jwt;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import tw.commonground.backend.service.user.entity.FullUserEntity;
+import tw.commonground.backend.service.user.entity.UserEntity;
+import tw.commonground.backend.service.user.entity.UserRepository;
+import tw.commonground.backend.service.user.entity.UserRole;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAccessUtilTest {
+
+    @Mock
+    private DecodedJWT mockJwt;
+
+    @Mock
+    private UserRepository userRepository;
+
+    JwtAccessUtil jwtAccessUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtAccessUtil = new JwtAccessUtil(null, userRepository);
+        ReflectionTestUtils.setField(jwtAccessUtil, "secret", "testSecret");
+        ReflectionTestUtils.setField(jwtAccessUtil, "accessTokenExpiration", "PT15M");
+        ReflectionTestUtils.setField(jwtAccessUtil, "refreshTokenExpiration", "P30D");
+        ReflectionTestUtils.setField(jwtAccessUtil, "issuer", "commonground");
+
+        jwtAccessUtil.postConstruct();
+    }
+
+    @Test
+    void testVerifyAccessToken_idIsNull_callsFetchEntityId() {
+        FullUserEntity user = createUser();
+        String token = jwtAccessUtil.generateAccessToken(user);
+        JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
+        Mockito.when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
+
+        assertThat(jwtUserDetails.getId()).isEqualTo(1L);
+
+        Mockito.verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
+    }
+
+    @Test
+    void testVerifyAccessToken_idIsNotNull_doesNotCallFetchEntityId() {
+        FullUserEntity user = createUser();
+
+        String token = jwtAccessUtil.generateAccessToken(user);
+        JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
+        ReflectionTestUtils.setField(jwtUserDetails, "id", 1L);
+
+        jwtUserDetails.getId();
+
+        Mockito.verify(userRepository, Mockito.never()).getIdByUid(user.getUuid());
+        assertThat(jwtUserDetails.getId()).isEqualTo(1L);
+    }
+
+    private UserEntity createUser() {
+        UserEntity user = new UserEntity();
+        user.setId(1L);
+        user.setUuid(UUID.randomUUID());
+        user.setUsername("username");
+        user.setEmail("email");
+        user.setNickname("nickname");
+        user.setRole(UserRole.ROLE_USER);
+        return user;
+    }
+}

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -1,6 +1,5 @@
 package tw.commonground.backend.service.jwt;
 
-import com.auth0.jwt.interfaces.DecodedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,9 +39,6 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("MethodName")
 @ExtendWith(MockitoExtension.class)
 class JwtAccessUtilTest {
-
-    @Mock
-    private DecodedJWT mockJwt;
 
     @Mock
     private UserRepository userRepository;

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -17,6 +17,24 @@ import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+/**
+ * Unit tests for the {@link JwtAccessUtil} class.
+ *
+ * <p>This class validates the behavior of handling JWT tokens in a secure manner.
+ * For security reasons, the JWT payload does not include the long ID directly.
+ * Instead, it contains a UUID, which is used to query the corresponding long ID
+ * from the database only when necessary. This design ensures that sensitive
+ * information (like long IDs) is not exposed directly in the JWT.</p>
+ *
+ * <p>The tests focus on the following scenarios:</p>
+ * <ul>
+ *     <li>When the ID is null, the system should correctly retrieve the long ID
+ *         from the database using the UUID provided in the JWT.</li>
+ *     <li>Once the ID is retrieved, it should be cached and subsequent requests
+ *         should not trigger additional database queries, ensuring efficiency.</li>
+ * </ul>
+ *
+ */
 @ExtendWith(MockitoExtension.class)
 class JwtAccessUtilTest {
 
@@ -63,6 +81,21 @@ class JwtAccessUtilTest {
 
         Mockito.verify(userRepository, Mockito.never()).getIdByUid(user.getUuid());
         assertThat(jwtUserDetails.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void testVerifyAccessToken_idIsNull_callsFetchEntityIdAndSetsId() {
+        FullUserEntity user = createUser();
+        String token = jwtAccessUtil.generateAccessToken(user);
+        JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
+        Mockito.when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
+
+        assertThat(jwtUserDetails.getId()).isEqualTo(1L);
+
+        Object fieldValue = ReflectionTestUtils.getField(jwtUserDetails, "id");
+        assertThat(fieldValue).isEqualTo(1L);
+
+        Mockito.verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
     }
 
     private UserEntity createUser() {

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -16,6 +16,8 @@ import tw.commonground.backend.service.user.entity.UserRole;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link JwtAccessUtil} class.
@@ -63,11 +65,11 @@ class JwtAccessUtilTest {
         FullUserEntity user = createUser();
         String token = jwtAccessUtil.generateAccessToken(user);
         JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
-        Mockito.when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
+        when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
 
         assertThat(jwtUserDetails.getId()).isEqualTo(1L);
 
-        Mockito.verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
+        verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
     }
 
     @Test
@@ -80,7 +82,7 @@ class JwtAccessUtilTest {
 
         jwtUserDetails.getId();
 
-        Mockito.verify(userRepository, Mockito.never()).getIdByUid(user.getUuid());
+        verify(userRepository, Mockito.never()).getIdByUid(user.getUuid());
         assertThat(jwtUserDetails.getId()).isEqualTo(1L);
     }
 
@@ -89,14 +91,14 @@ class JwtAccessUtilTest {
         FullUserEntity user = createUser();
         String token = jwtAccessUtil.generateAccessToken(user);
         JwtUserDetails jwtUserDetails = jwtAccessUtil.verifyAccessToken(token);
-        Mockito.when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
+        when(userRepository.getIdByUid(user.getUuid())).thenReturn(1L);
 
         assertThat(jwtUserDetails.getId()).isEqualTo(1L);
 
         Object fieldValue = ReflectionTestUtils.getField(jwtUserDetails, "id");
         assertThat(fieldValue).isEqualTo(1L);
 
-        Mockito.verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
+        verify(userRepository, Mockito.times(1)).getIdByUid(user.getUuid());
     }
 
     private UserEntity createUser() {

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtAccessUtilTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
  * </ul>
  *
  */
+@SuppressWarnings("MethodName")
 @ExtendWith(MockitoExtension.class)
 class JwtAccessUtilTest {
 
@@ -44,7 +45,7 @@ class JwtAccessUtilTest {
     @Mock
     private UserRepository userRepository;
 
-    JwtAccessUtil jwtAccessUtil;
+    private JwtAccessUtil jwtAccessUtil;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -8,12 +8,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tw.commonground.backend.service.jwt.dto.RefreshTokenResponse;
 import tw.commonground.backend.service.jwt.entity.RefreshTokenEntity;
+import tw.commonground.backend.service.jwt.entity.RefreshTokenProjectionImpl;
 import tw.commonground.backend.service.jwt.entity.RefreshTokenRepository;
+import tw.commonground.backend.service.jwt.exception.RefreshTokenInvalidException;
 import tw.commonground.backend.service.user.entity.UserEntity;
 import tw.commonground.backend.service.user.entity.UserRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,37 +37,108 @@ class JwtServiceTest {
     @Test
     void testGenerateTokens() {
         UserEntity user = createUser();
-        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken(EXPIRATION_TIME);
+        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken();
 
-        Mockito.when(jwtAccessUtil.generateAccessToken(user)).thenReturn("accessToken");
-        Mockito.when(jwtAccessUtil.generateRefreshToken(user)).thenReturn(refreshTokenEntity);
+        Mockito.when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+                .thenReturn("accessToken");
+
+        Mockito.when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+                .thenReturn(refreshTokenEntity);
 
         RefreshTokenResponse response = jwtService.generateTokens(user);
 
-        Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateAccessToken(user);
-        Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateRefreshToken(user);
+        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+                .generateAccessToken(user);
+
+        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+                .generateRefreshToken(user);
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
         assertThat(response.getRefreshToken()).isEqualTo(refreshTokenEntity.getId().toString());
     }
 
     @Test
-    void refreshToken() {
+    void testRefreshToken_validRefreshToken() {
+        UserEntity user = createUser();
+        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken();
+        refreshTokenEntity.setUser(user);
+
+        RefreshTokenEntity newRefreshTokenEntity = createActiveRefreshToken();
+        newRefreshTokenEntity.setUser(user);
+
+        Mockito.when(refreshTokenRepository
+                        .findByIdAndIsActiveAndExpirationTimeAfter(
+                                Mockito.eq(refreshTokenEntity.getId()),
+                                Mockito.eq(true),
+                                Mockito.anyLong()))
+                .thenReturn(Optional.of(createRefreshTokenProjection(refreshTokenEntity)));
+
+        Mockito.when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+                .thenReturn("accessToken");
+
+        Mockito.when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+                .thenReturn(newRefreshTokenEntity);
+
+        RefreshTokenResponse response = jwtService.refreshToken(refreshTokenEntity.getId());
+
+        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+                .findByIdAndIsActiveAndExpirationTimeAfter(Mockito.eq(refreshTokenEntity.getId()), Mockito.eq(true), Mockito.anyLong());
+
+        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+                .generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId())));
+
+        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+                .generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId())));
+
+        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+                .inactivateById(refreshTokenEntity.getId());
+
+        assertThat(response.getAccessToken()).isEqualTo("accessToken");
+        assertThat(response.getRefreshToken()).isEqualTo(newRefreshTokenEntity.getId().toString());
     }
 
-    private RefreshTokenEntity createActiveRefreshToken(Long expirationTime) {
+    @Test
+    void testRefreshToken_invalidRefreshToken() {
+        RefreshTokenEntity refreshTokenEntity = createInactiveRefreshToken();
+
+        Mockito.when(refreshTokenRepository
+                        .findByIdAndIsActiveAndExpirationTimeAfter(
+                                Mockito.eq(refreshTokenEntity.getId()),
+                                Mockito.eq(true),
+                                Mockito.anyLong()))
+                .thenReturn(Optional.empty());
+
+        UUID refreshToken = refreshTokenEntity.getId();
+        assertThrows(RefreshTokenInvalidException.class, () -> jwtService.refreshToken(refreshToken));
+
+        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+                .findByIdAndIsActiveAndExpirationTimeAfter(Mockito.eq(refreshTokenEntity.getId()), Mockito.eq(true), Mockito.anyLong());
+
+        Mockito.verify(jwtAccessUtil, Mockito.never()).generateAccessToken(Mockito.any());
+        Mockito.verify(jwtAccessUtil, Mockito.never()).generateRefreshToken(Mockito.any());
+        Mockito.verify(refreshTokenRepository, Mockito.never()).inactivateById(Mockito.any());
+    }
+
+    private RefreshTokenProjectionImpl createRefreshTokenProjection(RefreshTokenEntity refreshTokenEntity) {
+        RefreshTokenProjectionImpl refreshTokenProjection = new RefreshTokenProjectionImpl();
+        refreshTokenProjection.setId(refreshTokenEntity.getId().toString());
+        refreshTokenProjection.setUser(createUser());
+        return refreshTokenProjection;
+    }
+
+    private RefreshTokenEntity createActiveRefreshToken() {
         RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
         refreshTokenEntity.setId(UUID.randomUUID());
         refreshTokenEntity.setIsActive(true);
-        refreshTokenEntity.setExpirationTime(expirationTime);
+        refreshTokenEntity.setExpirationTime(JwtServiceTest.EXPIRATION_TIME);
         return refreshTokenEntity;
     }
 
-    private RefreshTokenEntity createInactiveRefreshToken(Long expirationTime) {
+    private RefreshTokenEntity createInactiveRefreshToken() {
         RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
         refreshTokenEntity.setId(UUID.randomUUID());
         refreshTokenEntity.setIsActive(false);
-        refreshTokenEntity.setExpirationTime(expirationTime);
+        refreshTokenEntity.setExpirationTime(JwtServiceTest.EXPIRATION_TIME);
         return refreshTokenEntity;
     }
 

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -30,6 +30,8 @@ class JwtServiceTest {
 
     private static final Long EXPIRATION_TIME = 1736658684976L;
 
+    private static final Long REFRESH_TOKEN_EXPIRATION_MILLIS = 1000L;
+
     @Mock
     private JwtAccessUtil jwtAccessUtil;
 
@@ -54,7 +56,7 @@ class JwtServiceTest {
                 .thenReturn(refreshTokenEntity);
 
         when(jwtAccessUtil.getRefreshTokenExpirationMillis())
-                .thenReturn(1000L);
+                .thenReturn(REFRESH_TOKEN_EXPIRATION_MILLIS);
 
         RefreshTokenResponse response = jwtService.generateTokens(user);
 
@@ -65,7 +67,8 @@ class JwtServiceTest {
                 .generateRefreshToken(user);
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
-        assertThat(response.getExpirationTime()).isEqualTo(clock.millis() + jwtAccessUtil.getRefreshTokenExpirationMillis());
+        assertThat(response.getExpirationTime()).isEqualTo(clock.millis() +
+                jwtAccessUtil.getRefreshTokenExpirationMillis());
         assertThat(response.getRefreshToken()).isEqualTo(refreshTokenEntity.getId().toString());
     }
 

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 @ExtendWith(MockitoExtension.class)
 class JwtServiceTest {
 
+    private static final Long EXPIRATION_TIME = System.currentTimeMillis() + 1000;
+
     @Mock
     private JwtAccessUtil jwtAccessUtil;
 
@@ -31,7 +33,7 @@ class JwtServiceTest {
     @Test
     void testGenerateTokens() {
         UserEntity user = createUser();
-        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken(System.currentTimeMillis() + 1000);
+        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken(EXPIRATION_TIME);
 
         Mockito.when(jwtAccessUtil.generateAccessToken(user)).thenReturn("accessToken");
         Mockito.when(jwtAccessUtil.generateRefreshToken(user)).thenReturn(refreshTokenEntity);
@@ -40,7 +42,6 @@ class JwtServiceTest {
 
         Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateAccessToken(user);
         Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateRefreshToken(user);
-//        todo: verify refreshTokenRepository method call
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
         assertThat(response.getRefreshToken()).isEqualTo(refreshTokenEntity.getId().toString());

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -1,0 +1,79 @@
+package tw.commonground.backend.service.jwt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tw.commonground.backend.service.jwt.dto.RefreshTokenResponse;
+import tw.commonground.backend.service.jwt.entity.RefreshTokenEntity;
+import tw.commonground.backend.service.jwt.entity.RefreshTokenRepository;
+import tw.commonground.backend.service.user.entity.UserEntity;
+import tw.commonground.backend.service.user.entity.UserRole;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+
+    @Mock
+    private JwtAccessUtil jwtAccessUtil;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    @Test
+    void testGenerateTokens() {
+        UserEntity user = createUser();
+        RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken(System.currentTimeMillis() + 1000);
+
+        Mockito.when(jwtAccessUtil.generateAccessToken(user)).thenReturn("accessToken");
+        Mockito.when(jwtAccessUtil.generateRefreshToken(user)).thenReturn(refreshTokenEntity);
+
+        RefreshTokenResponse response = jwtService.generateTokens(user);
+
+        Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateAccessToken(user);
+        Mockito.verify(jwtAccessUtil, Mockito.times(1)).generateRefreshToken(user);
+//        todo: verify refreshTokenRepository method call
+
+        assertThat(response.getAccessToken()).isEqualTo("accessToken");
+        assertThat(response.getRefreshToken()).isEqualTo(refreshTokenEntity.getId().toString());
+    }
+
+    @Test
+    void refreshToken() {
+    }
+
+    private RefreshTokenEntity createActiveRefreshToken(Long expirationTime) {
+        RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
+        refreshTokenEntity.setId(UUID.randomUUID());
+        refreshTokenEntity.setIsActive(true);
+        refreshTokenEntity.setExpirationTime(expirationTime);
+        return refreshTokenEntity;
+    }
+
+    private RefreshTokenEntity createInactiveRefreshToken(Long expirationTime) {
+        RefreshTokenEntity refreshTokenEntity = new RefreshTokenEntity();
+        refreshTokenEntity.setId(UUID.randomUUID());
+        refreshTokenEntity.setIsActive(false);
+        refreshTokenEntity.setExpirationTime(expirationTime);
+        return refreshTokenEntity;
+    }
+
+    private UserEntity createUser() {
+        UserEntity user = new UserEntity();
+        user.setId(1L);
+        user.setUuid(UUID.randomUUID());
+        user.setUsername("username");
+        user.setEmail("email");
+        user.setNickname("nickname");
+        user.setRole(UserRole.ROLE_USER);
+        return user;
+    }
+}

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -16,6 +16,8 @@ import tw.commonground.backend.service.user.entity.UserRole;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -40,18 +42,18 @@ class JwtServiceTest {
         UserEntity user = createUser();
         RefreshTokenEntity refreshTokenEntity = createActiveRefreshToken();
 
-        Mockito.when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+        when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
                 .thenReturn("accessToken");
 
-        Mockito.when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+        when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
                 .thenReturn(refreshTokenEntity);
 
         RefreshTokenResponse response = jwtService.generateTokens(user);
 
-        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+        verify(jwtAccessUtil, Mockito.times(1))
                 .generateAccessToken(user);
 
-        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+        verify(jwtAccessUtil, Mockito.times(1))
                 .generateRefreshToken(user);
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
@@ -67,33 +69,33 @@ class JwtServiceTest {
         RefreshTokenEntity newRefreshTokenEntity = createActiveRefreshToken();
         newRefreshTokenEntity.setUser(user);
 
-        Mockito.when(refreshTokenRepository
+        when(refreshTokenRepository
                         .findByIdAndIsActiveAndExpirationTimeAfter(
                                 Mockito.eq(refreshTokenEntity.getId()),
                                 Mockito.eq(true),
                                 Mockito.anyLong()))
                 .thenReturn(Optional.of(createRefreshTokenProjection(refreshTokenEntity)));
 
-        Mockito.when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+        when(jwtAccessUtil.generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
                 .thenReturn("accessToken");
 
-        Mockito.when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
+        when(jwtAccessUtil.generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId()))))
                 .thenReturn(newRefreshTokenEntity);
 
         RefreshTokenResponse response = jwtService.refreshToken(refreshTokenEntity.getId());
 
-        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+        verify(refreshTokenRepository, Mockito.times(1))
                 .findByIdAndIsActiveAndExpirationTimeAfter(
                         Mockito.eq(refreshTokenEntity.getId()),
                         Mockito.eq(true), Mockito.anyLong());
 
-        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+        verify(jwtAccessUtil, Mockito.times(1))
                 .generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId())));
 
-        Mockito.verify(jwtAccessUtil, Mockito.times(1))
+        verify(jwtAccessUtil, Mockito.times(1))
                 .generateRefreshToken(Mockito.argThat(u -> user.getId().equals(u.getId())));
 
-        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+        verify(refreshTokenRepository, Mockito.times(1))
                 .inactivateById(refreshTokenEntity.getId());
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
@@ -104,7 +106,7 @@ class JwtServiceTest {
     void testRefreshToken_invalidRefreshToken() {
         RefreshTokenEntity refreshTokenEntity = createInactiveRefreshToken();
 
-        Mockito.when(refreshTokenRepository
+        when(refreshTokenRepository
                         .findByIdAndIsActiveAndExpirationTimeAfter(
                                 Mockito.eq(refreshTokenEntity.getId()),
                                 Mockito.eq(true),
@@ -114,15 +116,15 @@ class JwtServiceTest {
         UUID refreshToken = refreshTokenEntity.getId();
         assertThrows(RefreshTokenInvalidException.class, () -> jwtService.refreshToken(refreshToken));
 
-        Mockito.verify(refreshTokenRepository, Mockito.times(1))
+        verify(refreshTokenRepository, Mockito.times(1))
                 .findByIdAndIsActiveAndExpirationTimeAfter(
                         Mockito.eq(refreshTokenEntity.getId()),
                         Mockito.eq(true),
                         Mockito.anyLong());
 
-        Mockito.verify(jwtAccessUtil, Mockito.never()).generateAccessToken(Mockito.any());
-        Mockito.verify(jwtAccessUtil, Mockito.never()).generateRefreshToken(Mockito.any());
-        Mockito.verify(refreshTokenRepository, Mockito.never()).inactivateById(Mockito.any());
+        verify(jwtAccessUtil, Mockito.never()).generateAccessToken(Mockito.any());
+        verify(jwtAccessUtil, Mockito.never()).generateRefreshToken(Mockito.any());
+        verify(refreshTokenRepository, Mockito.never()).inactivateById(Mockito.any());
     }
 
     private RefreshTokenProjectionImpl createRefreshTokenProjection(RefreshTokenEntity refreshTokenEntity) {

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -82,7 +82,9 @@ class JwtServiceTest {
         RefreshTokenResponse response = jwtService.refreshToken(refreshTokenEntity.getId());
 
         Mockito.verify(refreshTokenRepository, Mockito.times(1))
-                .findByIdAndIsActiveAndExpirationTimeAfter(Mockito.eq(refreshTokenEntity.getId()), Mockito.eq(true), Mockito.anyLong());
+                .findByIdAndIsActiveAndExpirationTimeAfter(
+                        Mockito.eq(refreshTokenEntity.getId()),
+                        Mockito.eq(true), Mockito.anyLong());
 
         Mockito.verify(jwtAccessUtil, Mockito.times(1))
                 .generateAccessToken(Mockito.argThat(u -> user.getId().equals(u.getId())));
@@ -112,7 +114,10 @@ class JwtServiceTest {
         assertThrows(RefreshTokenInvalidException.class, () -> jwtService.refreshToken(refreshToken));
 
         Mockito.verify(refreshTokenRepository, Mockito.times(1))
-                .findByIdAndIsActiveAndExpirationTimeAfter(Mockito.eq(refreshTokenEntity.getId()), Mockito.eq(true), Mockito.anyLong());
+                .findByIdAndIsActiveAndExpirationTimeAfter(
+                        Mockito.eq(refreshTokenEntity.getId()),
+                        Mockito.eq(true),
+                        Mockito.anyLong());
 
         Mockito.verify(jwtAccessUtil, Mockito.never()).generateAccessToken(Mockito.any());
         Mockito.verify(jwtAccessUtil, Mockito.never()).generateRefreshToken(Mockito.any());

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Optional;
 import java.util.UUID;
 
+@SuppressWarnings("MethodName")
 @ExtendWith(MockitoExtension.class)
 class JwtServiceTest {
 

--- a/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/JwtServiceTest.java
@@ -67,8 +67,8 @@ class JwtServiceTest {
                 .generateRefreshToken(user);
 
         assertThat(response.getAccessToken()).isEqualTo("accessToken");
-        assertThat(response.getExpirationTime()).isEqualTo(clock.millis() +
-                jwtAccessUtil.getRefreshTokenExpirationMillis());
+        assertThat(response.getExpirationTime()).isEqualTo(clock.millis()
+                + jwtAccessUtil.getRefreshTokenExpirationMillis());
         assertThat(response.getRefreshToken()).isEqualTo(refreshTokenEntity.getId().toString());
     }
 

--- a/src/test/java/tw/commonground/backend/service/jwt/package-info.java
+++ b/src/test/java/tw/commonground/backend/service/jwt/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.jwt;


### PR DESCRIPTION
## Type of Changes
Test

## Purpose
Add unit testing for `JwtAccessUtil` and `JwtService`

## Additional Information
- Add testing for `JwtServiceTest` to validate generation and refresh token logic with mocks.
- Add testing for `JwtAccessUtilTest` to validate the logic of dynamically obtaining long id.