### PR TITLE
Fix issue fact pagination sort empty

### DIFF
--- a/src/main/java/tw/commonground/backend/service/issue/IssueController.java
+++ b/src/main/java/tw/commonground/backend/service/issue/IssueController.java
@@ -102,8 +102,7 @@ public class IssueController {
     @GetMapping("/issue/{id}/facts")
     public WrappedPaginationResponse<List<FactResponse>> getIssueFacts(@PathVariable UUID id,
                                                                        @Valid PaginationRequest pagination) {
-        PaginationParser validator = new PaginationParser(Collections.emptySet(), MAX_SIZE);
-        Pageable pageable = validator.parsePageable(pagination);
+        Pageable pageable = paginationParser.parsePageable(pagination);
         Page<FactEntity> pageFacts = issueService.getIssueFacts(id, pageable);
 
         List<FactResponse> factResponses = pageFacts.getContent()


### PR DESCRIPTION
## Type of Changes
Fix

## Purpose
Fix issue fact endpoint use empty sort list in pagination parser
