### PR TITLE
Fix user react race condition

### DIFF
--- a/src/main/java/tw/commonground/backend/service/lock/LockService.java
+++ b/src/main/java/tw/commonground/backend/service/lock/LockService.java
@@ -1,0 +1,30 @@
+package tw.commonground.backend.service.lock;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+@Service
+public class LockService {
+
+    private final ConcurrentHashMap<String, Object> locks = new ConcurrentHashMap<>();
+
+    private final Object globalLock = new Object();
+
+    public <T> T executeWithLock(String key, Supplier<T> task) {
+        Object lock;
+
+        synchronized (globalLock) {
+            lock = locks.computeIfAbsent(key, k -> new Object());
+        }
+
+        synchronized (lock) {
+            try {
+                return task.get();
+            } finally {
+                locks.remove(key, lock);
+            }
+        }
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/lock/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/lock/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.lock;

--- a/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
+++ b/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
@@ -3,6 +3,7 @@ package tw.commonground.backend.service.viewpoint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import tw.commonground.backend.exception.EntityNotFoundException;
 import tw.commonground.backend.service.fact.FactService;
@@ -125,7 +126,7 @@ public class ViewpointService {
         viewpointRepository.deleteById(id);
     }
 
-    @Transactional
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     public ViewpointReactionEntity reactToViewpoint(Long userId, UUID viewpointId, Reaction reaction) {
         String lockKey = String.format(VIEWPOINT_REACTION_LOCK_FORMAT, viewpointId, userId);
 

--- a/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
+++ b/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
@@ -130,9 +130,11 @@ public class ViewpointService {
         synchronized (userReactionsLock.computeIfAbsent(lockKey, k -> new Object())) {
             ViewpointReactionKey viewpointReactionKey = new ViewpointReactionKey(userId, viewpointId);
 
-            Optional<ViewpointReactionEntity> reactionOptional = viewpointReactionRepository.findById(viewpointReactionKey);
+            Optional<ViewpointReactionEntity> reactionOptional =
+                    viewpointReactionRepository.findById(viewpointReactionKey);
+
             return reactionOptional
-                    .map(viewpointReactionEntity -> handleExistingReaction(viewpointReactionEntity, viewpointId, reaction))
+                    .map(reactionEntity -> handleExistingReaction(reactionEntity, viewpointId, reaction))
                     .orElseGet(() -> handleNewReaction(viewpointReactionKey, viewpointId, reaction));
         }
     }

--- a/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
+++ b/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointService.java
@@ -16,7 +16,6 @@ import tw.commonground.backend.service.viewpoint.entity.*;
 import tw.commonground.backend.shared.content.ContentContainFactParser;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Service


### PR DESCRIPTION
## Type of Changes
Fix

## Purpose
- Added a thread-safe mechanism using ConcurrentHashMap to manage locks (userReactionsLock) for user reactions. This prevents race conditions when multiple threads handle reactions for the same user-viewpoint combination.
- Improved synchronization for reactToViewpoint method by introducing locks to handle concurrent updates safely.