### PR TITLE
Organize all endpoint permissions and add default admin

### DIFF
--- a/src/main/java/tw/commonground/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/tw/commonground/backend/configuration/SecurityConfiguration.java
@@ -21,8 +21,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
-
-import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;

--- a/src/main/java/tw/commonground/backend/configuration/SecurityConfiguration.java
+++ b/src/main/java/tw/commonground/backend/configuration/SecurityConfiguration.java
@@ -5,6 +5,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,6 +22,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -76,7 +79,6 @@ public class SecurityConfiguration {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/api/setup/**").hasRole("SETUP_REQUIRED")
                         .requestMatchers("/api/debug/**").anonymous()
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/completed-sign-in.html").permitAll()
                         .requestMatchers("/login").permitAll()
                         .requestMatchers("/**").permitAll()
@@ -184,5 +186,10 @@ public class SecurityConfiguration {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.fromHierarchy("ROLE_ADMIN > ROLE_USER");
     }
 }

--- a/src/main/java/tw/commonground/backend/service/fact/FactController.java
+++ b/src/main/java/tw/commonground/backend/service/fact/FactController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import tw.commonground.backend.service.fact.dto.FactMapper;
@@ -48,12 +49,13 @@ public class FactController {
                 .toList();
 
         return ResponseEntity.ok(new WrappedPaginationResponse<>(factResponses,
-                                                                 PaginationMapper.toResponse(factEntityPage)));
+                PaginationMapper.toResponse(factEntityPage)));
     }
 
     @PostMapping("/api/facts")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<FactResponse> createFact(@AuthenticationPrincipal FullUserEntity user,
-                                   @Valid @RequestBody FactRequest factRequest) {
+                                                   @Valid @RequestBody FactRequest factRequest) {
         return ResponseEntity.ok(FactMapper.toResponse(factService.createFact(factRequest, user)));
     }
 
@@ -63,12 +65,14 @@ public class FactController {
     }
 
     @PutMapping("/api/fact/{id}")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<FactResponse> updateFact(@PathVariable String id,
                                                    @Valid @RequestBody FactRequest factRequest) {
         return ResponseEntity.ok(FactMapper.toResponse(factService.updateFact(UUID.fromString(id), factRequest)));
     }
 
     @DeleteMapping("/api/fact/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<String> deleteFact(@PathVariable String id) {
         factService.deleteFact(UUID.fromString(id));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
@@ -81,14 +85,16 @@ public class FactController {
     }
 
     @PostMapping("/api/fact/{id}/references")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<List<ReferenceResponse>> updateFactReferences(@PathVariable String id,
-                                                        @RequestBody List<@Valid ReferenceRequest> referenceRequests) {
+                                                                        @RequestBody List<@Valid ReferenceRequest> referenceRequests) {
 
         return ResponseEntity.ok(factService.createFactReferences(UUID.fromString(id), referenceRequests)
                 .stream().map(ReferenceMapper::toResponse).toList());
     }
 
     @DeleteMapping("/api/fact/{id}/reference/{referenceId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<String> deleteFactReferences(@PathVariable String id, @PathVariable String referenceId) {
         factService.deleteFactReferences(UUID.fromString(id), UUID.fromString(referenceId));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/tw/commonground/backend/service/fact/FactController.java
+++ b/src/main/java/tw/commonground/backend/service/fact/FactController.java
@@ -87,7 +87,8 @@ public class FactController {
     @PostMapping("/api/fact/{id}/references")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<List<ReferenceResponse>> updateFactReferences(@PathVariable String id,
-                                                                        @RequestBody List<@Valid ReferenceRequest> referenceRequests) {
+                                                                        @RequestBody List<@Valid ReferenceRequest>
+                                                                                referenceRequests) {
 
         return ResponseEntity.ok(factService.createFactReferences(UUID.fromString(id), referenceRequests)
                 .stream().map(ReferenceMapper::toResponse).toList());

--- a/src/main/java/tw/commonground/backend/service/issue/IssueController.java
+++ b/src/main/java/tw/commonground/backend/service/issue/IssueController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import tw.commonground.backend.service.fact.FactService;
@@ -59,6 +60,7 @@ public class IssueController {
     }
 
     @PostMapping("/issues")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<IssueResponse> createIssue(@AuthenticationPrincipal FullUserEntity user,
                                                      @Valid @RequestBody IssueRequest issueRequest) {
 
@@ -83,6 +85,7 @@ public class IssueController {
     }
 
     @PutMapping("/issue/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<IssueResponse> updateIssue(@PathVariable UUID id,
                                                      @Valid @RequestBody IssueRequest issueRequest) {
         IssueEntity issueEntity = issueService.updateIssue(id, issueRequest);
@@ -95,6 +98,7 @@ public class IssueController {
     }
 
     @DeleteMapping("/issue/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public void deleteIssue(@PathVariable String id) {
         issueService.deleteIssue(UUID.fromString(id));
     }
@@ -115,6 +119,7 @@ public class IssueController {
     }
 
     @PostMapping("/issue/{id}/facts")
+    @PreAuthorize("hasRole('ADMIN')")
     public Map<String, List<FactResponse>> linkFactsToIssue(@PathVariable UUID id,
                                                             @Valid @RequestBody LinkFactsRequest request) {
         List<FactEntity> factEntities = issueService.createManualFact(id, request.getFactIds());

--- a/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
+++ b/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
@@ -122,12 +122,16 @@ public class ReplyController {
         return new WrappedPaginationResponse<>(replyResponses, PaginationMapper.toResponse(pageReplies));
     }
 
-    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user, @PathVariable @NotNull UUID id, ReplyEntity replyEntity) {
+    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user,
+                                                                         @PathVariable @NotNull UUID id,
+                                                                         ReplyEntity replyEntity) {
         List<FactEntity> facts = replyService.getFactsOfReply(id);
         return getReplyResponseResponseEntity(user, replyEntity, facts);
     }
 
-    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user, ReplyEntity replyEntity, List<FactEntity> facts) {
+    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user,
+                                                                         ReplyEntity replyEntity,
+                                                                         List<FactEntity> facts) {
         List<QuoteReply> quotes = replyService.getQuotesOfReply(replyEntity.getId());
         List<ReplyEntity> replyEntities = replyService.getRepliesByQuotes(quotes);
         Reaction reaction = replyService.getReactionForReply(user.getId(), replyEntity.getId());

--- a/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
+++ b/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import tw.commonground.backend.service.fact.entity.FactEntity;
@@ -51,53 +52,42 @@ public class ReplyController {
     }
 
     @PostMapping("/viewpoint/{id}/replies")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ReplyResponse> createReplies(@AuthenticationPrincipal FullUserEntity user,
-                                                             @PathVariable @NotNull UUID id,
-                                                             @RequestBody @Valid ReplyRequest replyRequest) {
+                                                       @PathVariable @NotNull UUID id,
+                                                       @RequestBody @Valid ReplyRequest replyRequest) {
         ReplyEntity replyEntity = replyService.createViewpointReply(id, user, replyRequest);
         List<FactEntity> facts = replyService.getFactsOfReply(replyEntity.getId());
-        List<QuoteReply> quotes = replyService.getQuotesOfReply(replyEntity.getId());
-        List<ReplyEntity> replyEntities = replyService.getRepliesByQuotes(quotes);
-        Reaction reaction = replyService.getReactionForReply(user.getId(), replyEntity.getId());
-
-        return ResponseEntity.ok(ReplyMapper.toReplyResponse(replyEntity, reaction, facts, replyEntities, quotes));
+        return getReplyResponseResponseEntity(user, replyEntity, facts);
     }
 
     @GetMapping("/reply/{id}")
     public ResponseEntity<ReplyResponse> getReply(@AuthenticationPrincipal FullUserEntity user,
                                                   @PathVariable @NotNull UUID id) {
         ReplyEntity replyEntity = replyService.getReply(id);
-        List<FactEntity> facts = replyService.getFactsOfReply(id);
-        List<QuoteReply> quotes = replyService.getQuotesOfReply(replyEntity.getId());
-        List<ReplyEntity> replyEntities = replyService.getRepliesByQuotes(quotes);
-        Reaction reaction = replyService.getReactionForReply(user.getId(), replyEntity.getId());
-
-        return ResponseEntity.ok(ReplyMapper.toReplyResponse(replyEntity, reaction, facts, replyEntities, quotes));
+        return getReplyResponseResponseEntity(user, id, replyEntity);
     }
 
     @PutMapping("/reply/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ReplyResponse> updateReply(@AuthenticationPrincipal FullUserEntity user,
                                                      @PathVariable @NotNull UUID id,
                                                      @RequestBody @Valid ReplyRequest replyRequest) {
         ReplyEntity replyEntity = replyService.updateReply(id, replyRequest);
-        List<FactEntity> facts = replyService.getFactsOfReply(id);
-        List<QuoteReply> quotes = replyService.getQuotesOfReply(replyEntity.getId());
-        List<ReplyEntity> replyEntities = replyService.getRepliesByQuotes(quotes);
-        Reaction reaction = replyService.getReactionForReply(user.getId(), replyEntity.getId());
-
-        return ResponseEntity.ok(ReplyMapper.toReplyResponse(replyEntity, reaction, facts, replyEntities, quotes));
+        return getReplyResponseResponseEntity(user, id, replyEntity);
     }
 
     @DeleteMapping("/reply/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public void deleteReply(@AuthenticationPrincipal FullUserEntity user, @PathVariable @NotNull UUID id) {
         replyService.deleteReply(id);
     }
 
-//    @PreAuthorize("isAuthenticated()")
     @PostMapping("/reply/{id}/reaction/me")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ReactionResponse> reactToReply(@AuthenticationPrincipal FullUserEntity user,
-                                                           @PathVariable @NotNull UUID id,
-                                                           @RequestBody ReactionRequest reactionRequest) {
+                                                         @PathVariable @NotNull UUID id,
+                                                         @RequestBody ReactionRequest reactionRequest) {
         Long userId = user.getId();
         ReplyReactionEntity replyReactionEntity = replyService.reactToReply(userId, id, reactionRequest.getReaction());
 
@@ -112,7 +102,7 @@ public class ReplyController {
                 .stream().map(ReplyEntity::getId).toList());
 
         Map<UUID, List<QuoteReply>> quotesMap = replyService.getQuoteByReplies(pageReplies.getContent()
-            .stream().map(ReplyEntity::getId).toList());
+                .stream().map(ReplyEntity::getId).toList());
 
         Map<UUID, Reaction> reactionsMap = replyService.getReactionsForReplies(
                 userId,
@@ -130,5 +120,18 @@ public class ReplyController {
                 .toList();
 
         return new WrappedPaginationResponse<>(replyResponses, PaginationMapper.toResponse(pageReplies));
+    }
+
+    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user, @PathVariable @NotNull UUID id, ReplyEntity replyEntity) {
+        List<FactEntity> facts = replyService.getFactsOfReply(id);
+        return getReplyResponseResponseEntity(user, replyEntity, facts);
+    }
+
+    private ResponseEntity<ReplyResponse> getReplyResponseResponseEntity(@AuthenticationPrincipal FullUserEntity user, ReplyEntity replyEntity, List<FactEntity> facts) {
+        List<QuoteReply> quotes = replyService.getQuotesOfReply(replyEntity.getId());
+        List<ReplyEntity> replyEntities = replyService.getRepliesByQuotes(quotes);
+        Reaction reaction = replyService.getReactionForReply(user.getId(), replyEntity.getId());
+
+        return ResponseEntity.ok(ReplyMapper.toReplyResponse(replyEntity, reaction, facts, replyEntities, quotes));
     }
 }

--- a/src/main/java/tw/commonground/backend/service/timeline/TimelineController.java
+++ b/src/main/java/tw/commonground/backend/service/timeline/TimelineController.java
@@ -2,6 +2,7 @@ package tw.commonground.backend.service.timeline;
 
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import tw.commonground.backend.service.timeline.dto.*;
 import tw.commonground.backend.service.timeline.entity.NodeEntity;
@@ -27,6 +28,7 @@ public class TimelineController {
     }
 
     @PostMapping("/issue/{id}/timeline")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<NodeResponse> createNode(@PathVariable UUID id, @Valid @RequestBody NodeRequest request) {
         NodeEntity node = timelineService.createNode(id, request);
         NodeResponse response = NodeMapper.toResponse(node);
@@ -41,6 +43,7 @@ public class TimelineController {
     }
 
     @PutMapping("/timeline/node/{nodeId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<NodeResponse> updateNode(@PathVariable UUID nodeId, @Valid @RequestBody NodeRequest request) {
         NodeEntity node = timelineService.updateNode(nodeId, request);
         NodeResponse response = NodeMapper.toResponse(node);
@@ -48,6 +51,7 @@ public class TimelineController {
     }
 
     @DeleteMapping("/timeline/node/{nodeId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteNode(@PathVariable UUID nodeId) {
         timelineService.deleteNode(nodeId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/tw/commonground/backend/service/user/UserService.java
+++ b/src/main/java/tw/commonground/backend/service/user/UserService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -31,6 +32,9 @@ public class UserService {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Value("${application.admin.email:}")
+    private String adminEmail;
 
     public UserService(UserRepository userRepository, ImageService imageService) {
         this.userRepository = userRepository;
@@ -91,10 +95,15 @@ public class UserService {
             // instead of `@PreAuthorize("hasRole('SETUP_REQUIRED')")`
             throw new UserAlreadySetupException(email);
         } else {
+            UserRole defaultRole = UserRole.ROLE_USER;
+            if (adminEmail.equals(email)) {
+                defaultRole = UserRole.ROLE_ADMIN;
+            }
+
             userRepository.setupUserById(fullUser.getId(),
                     setupRequest.getUsername(),
                     setupRequest.getNickname(),
-                    UserRole.ROLE_USER);
+                    defaultRole);
 
             // Use to clear hibernate second level cache before fetching and returning user
             entityManager.clear();

--- a/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointController.java
+++ b/src/main/java/tw/commonground/backend/service/viewpoint/ViewpointController.java
@@ -51,6 +51,7 @@ public class ViewpointController {
     }
 
     @PostMapping("/issue/{id}/viewpoints")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ViewpointResponse> createViewpointForIssue(@AuthenticationPrincipal FullUserEntity user,
                                                                      @PathVariable UUID id,
                                                                      @RequestBody ViewpointRequest request) {
@@ -73,6 +74,7 @@ public class ViewpointController {
     }
 
     @PostMapping("/viewpoints")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ViewpointResponse> createViewpoint(@AuthenticationPrincipal FullUserEntity user,
                                                              @RequestBody ViewpointRequest request) {
         ViewpointEntity viewpointEntity = viewpointService.createViewpoint(request, user);
@@ -94,6 +96,7 @@ public class ViewpointController {
     }
 
     @PutMapping("/viewpoint/{id}")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ViewpointResponse> updateViewpoint(@AuthenticationPrincipal FullUserEntity user,
                                                              @PathVariable @NotNull UUID id,
                                                              @RequestBody ViewpointRequest updateRequest) {
@@ -106,13 +109,14 @@ public class ViewpointController {
     }
 
     @DeleteMapping("/viewpoint/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteViewPoint(@PathVariable @NotNull UUID id) {
         viewpointService.deleteViewpoint(id);
         return ResponseEntity.noContent().build();
     }
 
-    @PreAuthorize("isAuthenticated()")
     @PostMapping("/viewpoint/{id}/reaction/me")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ViewpointReactionResponse> reactToViewPoint(
             @AuthenticationPrincipal FullUserEntity user,
             @PathVariable UUID id,
@@ -147,30 +151,4 @@ public class ViewpointController {
 
         return new WrappedPaginationResponse<>(viewpointResponses, PaginationMapper.toResponse(pageViewpoints));
     }
-
-    // TODO: wait for page and size
-//    @GetMapping("/viewpoint/{id}/facts")
-//    public ResponseEntity<List<FactEntity>> getFactsOfViewPoint(
-//            @PathVariable @NotNull UUID id,
-//            @RequestParam(required = false) Integer page,
-//            @RequestParam(required = false) Integer size) {
-//        // Implement the logic to get facts of a viewpoint
-//        return ResponseEntity.ok(viewpointService.getFactsOfViewpoint(id, page, size));
-//    }
-
-//    @PostMapping("/viewpoint/{id}/facts")
-//    public ResponseEntity<ViewpointResponse> addFactToViewPoint(
-//            @PathVariable @NotNull UUID id,
-//            @RequestBody UUID factId) {
-//        ViewpointResponse response = ViewpointMapper.toResponse(viewpointService.addFactToViewpoint(id, factId));
-//        return ResponseEntity.ok(response);
-//    }
-
-//    @DeleteMapping("/viewpoint/{id}/facts/{factId}")
-//    public ResponseEntity<Void> removeFactFromViewPoint(
-//            @PathVariable @NotNull UUID id,
-//            @PathVariable @NotNull UUID factId) {
-//        viewpointService.deleteFactFromViewpoint(id, factId);
-//        return ResponseEntity.noContent().build();
-//    }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -41,6 +41,12 @@
       "type": "java.lang.String",
       "description": "Description for jwt.state.expiration.",
       "defaultValue": ""
+    },
+    {
+      "name": "application.admin.email",
+      "type": "java.lang.String",
+      "description": "Description for application.admin.email.",
+      "defaultValue": ""
     }
   ]
 }


### PR DESCRIPTION
## Type of Changes
Refactor & Feature

## Purpose
- Add correct permissions to all endpoints
- Add admin.email config to allow the system to create an initial system administrator

## Additional Information
### Permissions
- Read-only endpoints can be accessed without logging in
- Endpoints for creating resources require at least USER-level permissions or higher to access
- Endpoints for updating or deleting resources are not supported (as they are not included in the current specification). If such endpoints are accessed, they require ADMIN-level permissions as a minimum

### Default Admin

```properties
application.admin.email=admin@example.com
```
After the user setup is completed, the permissions will be elevated to admin.