### PR TITLE
Add internal profile api

### DIFF
--- a/src/main/java/tw/commonground/backend/service/internal/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileController.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileController.java
@@ -1,0 +1,31 @@
+package tw.commonground.backend.service.internal.profile;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/internal/users/profile")
+public class InternalProfileController {
+
+    private final InternalProfileService internalProfileService;
+
+    public InternalProfileController(InternalProfileService internalProfileService) {
+        this.internalProfileService = internalProfileService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<InternalProfileResponse>> getProfiles() {
+        List<InternalProfileResponse> profiles = internalProfileService.getProfiles();
+        return ResponseEntity.ok(profiles);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<InternalProfileResponse> getProfile(@PathVariable UUID userId) {
+        InternalProfileResponse profile = internalProfileService.getProfile(userId);
+        return ResponseEntity.ok(profile);
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -62,6 +62,7 @@ public class InternalProfileService {
         UserEntity user = entityManager.getReference(UserEntity.class, userId);
 
         InternalProfileEntity newProfile = InternalProfileEntity.builder()
+                .uuid(user.getUuid())
                 .user(user)
                 .gender("")
                 .occupation("")

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -1,29 +1,102 @@
 package tw.commonground.backend.service.internal.profile;
 
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import tw.commonground.backend.service.internal.profile.dto.InternalProfileMapper;
 import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileEntity;
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileRepository;
+import tw.commonground.backend.service.user.UserCreatedEvent;
 import tw.commonground.backend.service.user.entity.UserEntity;
 import tw.commonground.backend.service.user.entity.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 @Service
 public class InternalProfileService {
     private final UserRepository userRepository;
+    private final InternalProfileRepository internalProfileRepository;
 
-    public InternalProfileService(UserRepository userRepository) {
+    public InternalProfileService(UserRepository userRepository, InternalProfileRepository internalProfileRepository) {
         this.userRepository = userRepository;
+        this.internalProfileRepository = internalProfileRepository;
     }
 
     public List<InternalProfileResponse> getProfiles() {
-        List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
-        return InternalProfileMapper.toResponses(users);
+        List<InternalProfileEntity> internalProfileEntities = internalProfileRepository.findAll();
+        return InternalProfileMapper.toResponses(internalProfileEntities);
     }
 
-    public InternalProfileResponse getProfile(UUID userId) {
-        return InternalProfileMapper.toResponseFromId(userId);
+    public InternalProfileResponse getProfile(UUID userUuid) {
+        Long userId = userRepository.getIdByUid(userUuid);
+        InternalProfileEntity internalProfileEntity =  internalProfileRepository.findById(userId)
+                .orElseGet(() -> {
+                    InternalProfileEntity newProfileEntity = InternalProfileEntity.builder()
+                            .uuid(userUuid)
+                            .gender("")
+                            .occupation("")
+                            .location("")
+                            .browsingTags(List.of())
+                            .searchKeywords(List.of())
+                            .createdAt(LocalDateTime.now())
+                            .lastActiveAt(LocalDateTime.now())
+                            .activityFrequency(List.of())
+                            .userTopIp(List.of())
+                            .build();
+                    return internalProfileRepository.save(newProfileEntity);
+                });
+        return InternalProfileMapper.toResponse(internalProfileEntity);
+    }
+
+    public void createProfile(UserEntity userEntity) {
+        if (userEntity == null || userEntity.getId() == null) {
+            throw new IllegalArgumentException("UserEntity cannot be null and must have an ID before creating a profile.");
+        }
+
+        InternalProfileEntity newProfile = InternalProfileEntity.builder()
+                .id(userEntity.getId())
+                .uuid(userEntity.getUuid())
+                .user(userEntity)
+                .gender("")
+                .occupation("")
+                .location("")
+                .browsingTags(List.of())
+                .searchKeywords(List.of())
+                .createdAt(LocalDateTime.now())
+                .lastActiveAt(LocalDateTime.now())
+                .activityFrequency(List.of())
+                .userTopIp(List.of())
+                .build();
+
+        internalProfileRepository.save(newProfile);
+    }
+
+    @EventListener
+    public void onUserCreatedEvent(UserCreatedEvent userEvent) {
+        UserEntity userEntity = userEvent.getUserEntity();
+
+        if (userEntity == null || userEntity.getId() == null) {
+            throw new IllegalStateException("UserEntity is null or does not have an ID when creating profile.");
+        }
+
+        internalProfileRepository.findById(userEntity.getId()).ifPresentOrElse(
+                profile -> {},
+                () -> createProfile(userEntity)
+        );
+    }
+
+    @EventListener
+    public void onApplicationStart(ContextRefreshedEvent event) {
+        List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
+        for (UserEntity user : users) {
+            internalProfileRepository.findById(user.getId()).ifPresentOrElse(
+                    profile -> {},
+                    () -> createProfile(user)
+            );
+        }
     }
 }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -25,7 +25,7 @@ public class InternalProfileService {
     }
 
     public InternalProfileResponse getProfile(UUID userId) {
-        UserEntity user = (UserEntity) userRepository.findUserEntityByUuid(userId)
+        UserEntity user = userRepository.findUserEntityByUuid(userId)
                 .orElseThrow(() -> new EntityNotFoundException("InternalProfile", "user id", userId.toString()));
 
         return InternalProfileMapper.toResponse(user);

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -81,7 +81,7 @@ public class InternalProfileService {
         UserEntity userEntity = userEvent.getUserEntity();
 
         internalProfileRepository.findById(userEntity.getId()).ifPresentOrElse(
-                profile -> {},
+                profile -> { },
                 () -> createProfile(userEntity.getId())
         );
     }
@@ -91,12 +91,12 @@ public class InternalProfileService {
         long userCount = userRepository.count();
         long profileCount = internalProfileRepository.count();
 
-        if (userCount == profileCount) return;
+        if (userCount == profileCount) { return; }
 
         List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
         for (UserEntity user : users) {
             internalProfileRepository.findById(user.getId()).ifPresentOrElse(
-                    profile -> {},
+                    profile -> { },
                     () -> createProfile(user.getId())
             );
         }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -91,7 +91,9 @@ public class InternalProfileService {
         long userCount = userRepository.count();
         long profileCount = internalProfileRepository.count();
 
-        if (userCount == profileCount) { return; }
+        if (userCount == profileCount) {
+            return;
+        }
 
         List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
         for (UserEntity user : users) {

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -1,0 +1,33 @@
+package tw.commonground.backend.service.internal.profile;
+
+import org.springframework.stereotype.Service;
+
+import tw.commonground.backend.exception.EntityNotFoundException;
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileMapper;
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
+import tw.commonground.backend.service.user.entity.UserEntity;
+import tw.commonground.backend.service.user.entity.UserRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class InternalProfileService {
+    private final UserRepository userRepository;
+
+    public InternalProfileService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<InternalProfileResponse> getProfiles() {
+        List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
+        return InternalProfileMapper.toResponses(users);
+    }
+
+    public InternalProfileResponse getProfile(UUID userId) {
+        UserEntity user = (UserEntity) userRepository.findUserEntityByUuid(userId)
+                .orElseThrow(() -> new EntityNotFoundException("InternalProfile", "user id", userId.toString()));
+
+        return InternalProfileMapper.toResponse(user);
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -2,7 +2,6 @@ package tw.commonground.backend.service.internal.profile;
 
 import org.springframework.stereotype.Service;
 
-import tw.commonground.backend.exception.EntityNotFoundException;
 import tw.commonground.backend.service.internal.profile.dto.InternalProfileMapper;
 import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
 import tw.commonground.backend.service.user.entity.UserEntity;
@@ -25,9 +24,6 @@ public class InternalProfileService {
     }
 
     public InternalProfileResponse getProfile(UUID userId) {
-        UserEntity user = userRepository.findUserEntityByUuid(userId)
-                .orElseThrow(() -> new EntityNotFoundException("InternalProfile", "user id", userId.toString()));
-
-        return InternalProfileMapper.toResponse(user);
+        return InternalProfileMapper.toResponseFromId(userId);
     }
 }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
@@ -3,11 +3,18 @@ package tw.commonground.backend.service.internal.profile.dto;
 import tw.commonground.backend.service.user.entity.UserEntity;
 
 import java.util.List;
+import java.util.UUID;
 
 public final class InternalProfileMapper {
 
     private InternalProfileMapper() {
         // hide constructor
+    }
+
+    public static InternalProfileResponse toResponseFromId(UUID userId) {
+        return InternalProfileResponse.builder()
+                .userId(userId)
+                .build();
     }
 
     public static InternalProfileResponse toResponse(UserEntity user) {

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
@@ -1,9 +1,8 @@
 package tw.commonground.backend.service.internal.profile.dto;
 
-import tw.commonground.backend.service.user.entity.UserEntity;
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileEntity;
 
 import java.util.List;
-import java.util.UUID;
 
 public final class InternalProfileMapper {
 
@@ -11,20 +10,23 @@ public final class InternalProfileMapper {
         // hide constructor
     }
 
-    public static InternalProfileResponse toResponseFromId(UUID userId) {
+    public static InternalProfileResponse toResponse(InternalProfileEntity internalProfileEntity) {
         return InternalProfileResponse.builder()
-                .userId(userId)
+                .userUuid(internalProfileEntity.getUuid())
+                .gender(internalProfileEntity.getGender())
+                .occupation(internalProfileEntity.getOccupation())
+                .location(internalProfileEntity.getLocation())
+                .browsingTags(internalProfileEntity.getBrowsingTags())
+                .searchKeywords(internalProfileEntity.getSearchKeywords())
+                .createdAt(internalProfileEntity.getCreatedAt())
+                .lastActiveAt(internalProfileEntity.getLastActiveAt())
+                .activityFrequency(internalProfileEntity.getActivityFrequency())
+                .userTopIp(internalProfileEntity.getUserTopIp())
                 .build();
     }
 
-    public static InternalProfileResponse toResponse(UserEntity user) {
-        return InternalProfileResponse.builder()
-                .userId(user.getUuid())
-                .build();
-    }
-
-    public static List<InternalProfileResponse> toResponses(List<UserEntity> users) {
-        return users.stream()
+    public static List<InternalProfileResponse> toResponses(List<InternalProfileEntity> internalProfileEntities) {
+        return internalProfileEntities.stream()
                 .map(InternalProfileMapper::toResponse)
                 .toList();
     }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
@@ -1,0 +1,24 @@
+package tw.commonground.backend.service.internal.profile.dto;
+
+import tw.commonground.backend.service.user.entity.UserEntity;
+
+import java.util.List;
+
+public final class InternalProfileMapper {
+
+    private InternalProfileMapper() {
+        // hide constructor
+    }
+
+    public static InternalProfileResponse toResponse(UserEntity user) {
+        return InternalProfileResponse.builder()
+                .userId(user.getUuid())
+                .build();
+    }
+
+    public static List<InternalProfileResponse> toResponses(List<UserEntity> users) {
+        return users.stream()
+                .map(InternalProfileMapper::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
@@ -1,5 +1,6 @@
 package tw.commonground.backend.service.internal.profile.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 public class InternalProfileResponse {
+    @JsonProperty("user_id")
     private UUID userId;
 
     @Builder.Default
@@ -25,20 +27,26 @@ public class InternalProfileResponse {
     private String location = "";
 
     @Builder.Default
+    @JsonProperty("browsing_tags")
     private List<String> browsingTags = Collections.emptyList();
 
     @Builder.Default
+    @JsonProperty("search_keywords")
     private List<String> searchKeywords = Collections.emptyList();
 
     @Builder.Default
+    @JsonProperty("created_at")
     private LocalDateTime createdAt = null;
 
     @Builder.Default
+    @JsonProperty("last_active_at")
     private LocalDateTime lastActiveAt = null;
 
     @Builder.Default
+    @JsonProperty("activity_frequency")
     private Object activityFrequency = Collections.emptyMap();
 
     @Builder.Default
+    @JsonProperty("user_top_ip")
     private Object userTopIp = Collections.emptyMap();
 }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @NoArgsConstructor
 public class InternalProfileResponse {
     @JsonProperty("user_id")
-    private UUID userId;
+    private UUID userUuid;
 
     @Builder.Default
     private String gender = "";

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
@@ -1,0 +1,44 @@
+package tw.commonground.backend.service.internal.profile.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InternalProfileResponse {
+    private UUID userId;
+
+    @Builder.Default
+    private String gender = "";
+
+    @Builder.Default
+    private String occupation = "";
+
+    @Builder.Default
+    private String location = "";
+
+    @Builder.Default
+    private List<String> browsingTags = Collections.emptyList();
+
+    @Builder.Default
+    private List<String> searchKeywords = Collections.emptyList();
+
+    @Builder.Default
+    private LocalDateTime createdAt = null;
+
+    @Builder.Default
+    private LocalDateTime lastActiveAt = null;
+
+    @Builder.Default
+    private Object activityFrequency = Collections.emptyMap();
+
+    @Builder.Default
+    private Object userTopIp = Collections.emptyMap();
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile.dto;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/ActivityFrequencyEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/ActivityFrequencyEntity.java
@@ -1,0 +1,20 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityFrequencyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "profile_id", nullable = false)
+    private InternalProfileEntity profile;
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
@@ -16,20 +16,33 @@ import tw.commonground.backend.service.user.entity.UserEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 public class InternalProfileEntity {
-    @Id
-    @Column(name = "user_id")
-    private UUID userId;
 
-    @OneToOne
+    @Id
+    private Long id;
+
+    private UUID uuid;
+
     @MapsId
-    @JoinColumn(name = "user_id", referencedColumnName = "uuid", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
     private UserEntity user;
 
     private String gender;
     private String occupation;
     private String location;
 
+//    @Column(columnDefinition = "text[]")
+//    @Type(value = tw.commonground.backend.service.internal.profile.entity.CustomStringArrayType.class)
+//    private String[] browsingTags;
+    @Column(name = "browsingTags")
+    @Convert(converter = ListToStringConverter.class)
     private List<String> browsingTags;
+
+//    @Column(columnDefinition = "text[]")
+//    @Type(value = tw.commonground.backend.service.internal.profile.entity.CustomStringArrayType.class)
+//    private String[] searchKeywords;
+    @Column(name = "searchKeywords")
+    @Convert(converter = ListToStringConverter.class)
     private List<String> searchKeywords;
 
     private LocalDateTime createdAt;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
@@ -7,6 +7,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import tw.commonground.backend.service.user.entity.UserEntity;
 
 @Entity
@@ -15,8 +18,8 @@ import tw.commonground.backend.service.user.entity.UserEntity;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class InternalProfileEntity {
-
     @Id
     private Long id;
 
@@ -31,21 +34,18 @@ public class InternalProfileEntity {
     private String occupation;
     private String location;
 
-//    @Column(columnDefinition = "text[]")
-//    @Type(value = tw.commonground.backend.service.internal.profile.entity.CustomStringArrayType.class)
-//    private String[] browsingTags;
     @Column(name = "browsingTags")
     @Convert(converter = ListToStringConverter.class)
     private List<String> browsingTags;
 
-//    @Column(columnDefinition = "text[]")
-//    @Type(value = tw.commonground.backend.service.internal.profile.entity.CustomStringArrayType.class)
-//    private String[] searchKeywords;
     @Column(name = "searchKeywords")
     @Convert(converter = ListToStringConverter.class)
     private List<String> searchKeywords;
 
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    @LastModifiedDate
     private LocalDateTime lastActiveAt;
 
     @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -53,10 +53,4 @@ public class InternalProfileEntity {
 
     @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserTopIpEntity> userTopIp;
-
-    @PrePersist
-    protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        lastActiveAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
@@ -1,0 +1,49 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import tw.commonground.backend.service.user.entity.UserEntity;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InternalProfileEntity {
+    @Id
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id", referencedColumnName = "uuid", nullable = false)
+    private UserEntity user;
+
+    private String gender;
+    private String occupation;
+    private String location;
+
+    private List<String> browsingTags;
+    private List<String> searchKeywords;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime lastActiveAt;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityFrequencyEntity> activityFrequency;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserTopIpEntity> userTopIp;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        lastActiveAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileRepository.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileRepository.java
@@ -1,0 +1,7 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InternalProfileRepository extends JpaRepository<InternalProfileEntity, Long> {
+
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
@@ -3,13 +3,12 @@ package tw.commonground.backend.service.internal.profile.entity;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 @Converter
-public class ListToStringConverter implements AttributeConverter<List<String>,String> {
+public class ListToStringConverter implements AttributeConverter<List<String>, String> {
     @Override
     public String convertToDatabaseColumn(List<String> attribute) {
         return attribute == null ? null : String.join(",", attribute);
@@ -20,7 +19,6 @@ public class ListToStringConverter implements AttributeConverter<List<String>,St
         if (columnValue == null || columnValue.trim().isEmpty()) {
             return Collections.emptyList();
         }
-
         return Arrays.asList(columnValue.split(","));
     }
 }

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
@@ -1,0 +1,26 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class ListToStringConverter implements AttributeConverter<List<String>,String> {
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute == null ? null : String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String columnValue) {
+        if (columnValue == null || columnValue.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.asList(columnValue.split(","));
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/UserTopIpEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/UserTopIpEntity.java
@@ -1,0 +1,20 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTopIpEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "profile_id", nullable = false)
+    private InternalProfileEntity profile;
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile.entity;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile;

--- a/src/main/java/tw/commonground/backend/service/user/UserCreatedEvent.java
+++ b/src/main/java/tw/commonground/backend/service/user/UserCreatedEvent.java
@@ -1,0 +1,16 @@
+package tw.commonground.backend.service.user;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import tw.commonground.backend.service.user.entity.UserEntity;
+
+@Getter
+public class UserCreatedEvent extends ApplicationEvent {
+
+    private final UserEntity userEntity;
+
+    public UserCreatedEvent(UserEntity userEntity) {
+        super(userEntity);
+        this.userEntity = userEntity;
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/user/UserService.java
+++ b/src/main/java/tw/commonground/backend/service/user/UserService.java
@@ -38,7 +38,10 @@ public class UserService {
     @Value("${application.admin.email:}")
     private String adminEmail;
 
-    public UserService(UserRepository userRepository, ImageService imageService, ApplicationEventPublisher applicationEventPublisher) {
+    public UserService(
+            UserRepository userRepository,
+            ImageService imageService,
+            ApplicationEventPublisher applicationEventPublisher) {
         this.userRepository = userRepository;
         this.imageService = imageService;
         this.applicationEventPublisher = applicationEventPublisher;

--- a/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
+++ b/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
@@ -20,8 +20,6 @@ public interface UserRepository extends CrudRepository<UserEntity, Long> {
 
     Optional<FullUserEntity> findIdByEmail(String email);
 
-    Optional<UserEntity> findUserEntityByUuid(UUID uuid);
-
     Optional<UserEntity> getUserEntityByUsername(String username);
 
     SimpleUserEntity findByEmail(String email);

--- a/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
+++ b/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
@@ -18,6 +18,8 @@ public interface UserRepository extends CrudRepository<UserEntity, Long> {
 
     Optional<FullUserEntity> findUserEntityById(Long id);
 
+    Optional<FullUserEntity> findUserEntityByUuid(UUID uuid);
+
     Optional<FullUserEntity> findIdByEmail(String email);
 
     Optional<UserEntity> getUserEntityByUsername(String username);

--- a/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
+++ b/src/main/java/tw/commonground/backend/service/user/entity/UserRepository.java
@@ -18,9 +18,9 @@ public interface UserRepository extends CrudRepository<UserEntity, Long> {
 
     Optional<FullUserEntity> findUserEntityById(Long id);
 
-    Optional<FullUserEntity> findUserEntityByUuid(UUID uuid);
-
     Optional<FullUserEntity> findIdByEmail(String email);
+
+    Optional<UserEntity> findUserEntityByUuid(UUID uuid);
 
     Optional<UserEntity> getUserEntityByUsername(String username);
 


### PR DESCRIPTION
## Type of Changes
- Feature

## Purpose
- Add `/api/internal/users/profile` to get all internal user profile information
- Add `/api/internal/users/profile/{userId}` to get specific internal user profile information by user ID

## Additional Information
- The schemas for `activity_frequency` and `user_top_ip` have yet to be designed.

