### PR TITLE
Fix failed test due to adding preset sort

### DIFF
--- a/src/test/java/tw/commonground/backend/shared/pagination/PaginationParserTest.java
+++ b/src/test/java/tw/commonground/backend/shared/pagination/PaginationParserTest.java
@@ -101,7 +101,8 @@ class PaginationParserTest {
         PaginationRequest request = new PaginationRequest(0, 10, null);
         Pageable pageable = parser.parsePageable(request);
 
-        assertThat(pageable.getSort().isUnsorted()).isTrue();
+        assertThat(Objects.requireNonNull(pageable.getSort().getOrderFor("createdAt"))
+                .getDirection()).isEqualTo(Sort.Direction.DESC);
     }
 
     @Test
@@ -109,7 +110,8 @@ class PaginationParserTest {
         PaginationRequest request = new PaginationRequest(0, 10, " ");
         Pageable pageable = parser.parsePageable(request);
 
-        assertThat(pageable.getSort().isUnsorted()).isTrue();
+        assertThat(Objects.requireNonNull(pageable.getSort().getOrderFor("createdAt"))
+                .getDirection()).isEqualTo(Sort.Direction.DESC);
     }
 
     @Test


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
Merge "Set default sorting order in pagination parser" but the test is not updated