### PR TITLE
Revert "Revert "Add internal profile api""

### DIFF
--- a/src/main/java/tw/commonground/backend/service/internal/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileController.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileController.java
@@ -1,0 +1,31 @@
+package tw.commonground.backend.service.internal.profile;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/internal/users/profile")
+public class InternalProfileController {
+
+    private final InternalProfileService internalProfileService;
+
+    public InternalProfileController(InternalProfileService internalProfileService) {
+        this.internalProfileService = internalProfileService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<InternalProfileResponse>> getProfiles() {
+        List<InternalProfileResponse> profiles = internalProfileService.getProfiles();
+        return ResponseEntity.ok(profiles);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<InternalProfileResponse> getProfile(@PathVariable UUID userId) {
+        InternalProfileResponse profile = internalProfileService.getProfile(userId);
+        return ResponseEntity.ok(profile);
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -55,7 +55,6 @@ public class InternalProfileService {
 
     @Transactional
     public void createProfile(Long userId) {
-//        UserEntity user = entityManager.getReference(UserEntity.class, userId);
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -1,7 +1,5 @@
 package tw.commonground.backend.service.internal.profile;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
@@ -23,9 +21,6 @@ import java.util.UUID;
 public class InternalProfileService {
     private final UserRepository userRepository;
     private final InternalProfileRepository internalProfileRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     public InternalProfileService(UserRepository userRepository, InternalProfileRepository internalProfileRepository) {
         this.userRepository = userRepository;
@@ -58,8 +53,11 @@ public class InternalProfileService {
         return InternalProfileMapper.toResponse(internalProfileEntity);
     }
 
+    @Transactional
     public void createProfile(Long userId) {
-        UserEntity user = entityManager.getReference(UserEntity.class, userId);
+//        UserEntity user = entityManager.getReference(UserEntity.class, userId);
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
 
         InternalProfileEntity newProfile = InternalProfileEntity.builder()
                 .uuid(user.getUuid())
@@ -88,6 +86,7 @@ public class InternalProfileService {
     }
 
     @EventListener
+    @Transactional
     public void onApplicationStart(ContextRefreshedEvent event) {
         long userCount = userRepository.count();
         long profileCount = internalProfileRepository.count();

--- a/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/InternalProfileService.java
@@ -1,0 +1,107 @@
+package tw.commonground.backend.service.internal.profile;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileMapper;
+import tw.commonground.backend.service.internal.profile.dto.InternalProfileResponse;
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileEntity;
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileRepository;
+import tw.commonground.backend.service.user.UserCreatedEvent;
+import tw.commonground.backend.service.user.entity.UserEntity;
+import tw.commonground.backend.service.user.entity.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class InternalProfileService {
+    private final UserRepository userRepository;
+    private final InternalProfileRepository internalProfileRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public InternalProfileService(UserRepository userRepository, InternalProfileRepository internalProfileRepository) {
+        this.userRepository = userRepository;
+        this.internalProfileRepository = internalProfileRepository;
+    }
+
+    public List<InternalProfileResponse> getProfiles() {
+        List<InternalProfileEntity> internalProfileEntities = internalProfileRepository.findAll();
+        return InternalProfileMapper.toResponses(internalProfileEntities);
+    }
+
+    public InternalProfileResponse getProfile(UUID userUuid) {
+        Long userId = userRepository.getIdByUid(userUuid);
+        InternalProfileEntity internalProfileEntity =  internalProfileRepository.findById(userId)
+                .orElseGet(() -> {
+                    InternalProfileEntity newProfileEntity = InternalProfileEntity.builder()
+                            .uuid(userUuid)
+                            .gender("")
+                            .occupation("")
+                            .location("")
+                            .browsingTags(List.of())
+                            .searchKeywords(List.of())
+                            .createdAt(LocalDateTime.now())
+                            .lastActiveAt(LocalDateTime.now())
+                            .activityFrequency(List.of())
+                            .userTopIp(List.of())
+                            .build();
+                    return internalProfileRepository.save(newProfileEntity);
+                });
+        return InternalProfileMapper.toResponse(internalProfileEntity);
+    }
+
+    public void createProfile(Long userId) {
+        UserEntity user = entityManager.getReference(UserEntity.class, userId);
+
+        InternalProfileEntity newProfile = InternalProfileEntity.builder()
+                .uuid(user.getUuid())
+                .user(user)
+                .gender("")
+                .occupation("")
+                .location("")
+                .browsingTags(List.of())
+                .searchKeywords(List.of())
+                .activityFrequency(List.of())
+                .userTopIp(List.of())
+                .build();
+
+        internalProfileRepository.save(newProfile);
+    }
+
+    @EventListener
+    @Transactional
+    public void onUserCreatedEvent(UserCreatedEvent userEvent) {
+        UserEntity userEntity = userEvent.getUserEntity();
+
+        internalProfileRepository.findById(userEntity.getId()).ifPresentOrElse(
+                profile -> { },
+                () -> createProfile(userEntity.getId())
+        );
+    }
+
+    @EventListener
+    public void onApplicationStart(ContextRefreshedEvent event) {
+        long userCount = userRepository.count();
+        long profileCount = internalProfileRepository.count();
+
+        if (userCount == profileCount) {
+            return;
+        }
+
+        List<UserEntity> users = (List<UserEntity>) userRepository.findAll();
+        for (UserEntity user : users) {
+            internalProfileRepository.findById(user.getId()).ifPresentOrElse(
+                    profile -> { },
+                    () -> createProfile(user.getId())
+            );
+        }
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileMapper.java
@@ -1,0 +1,33 @@
+package tw.commonground.backend.service.internal.profile.dto;
+
+import tw.commonground.backend.service.internal.profile.entity.InternalProfileEntity;
+
+import java.util.List;
+
+public final class InternalProfileMapper {
+
+    private InternalProfileMapper() {
+        // hide constructor
+    }
+
+    public static InternalProfileResponse toResponse(InternalProfileEntity internalProfileEntity) {
+        return InternalProfileResponse.builder()
+                .userUuid(internalProfileEntity.getUuid())
+                .gender(internalProfileEntity.getGender())
+                .occupation(internalProfileEntity.getOccupation())
+                .location(internalProfileEntity.getLocation())
+                .browsingTags(internalProfileEntity.getBrowsingTags())
+                .searchKeywords(internalProfileEntity.getSearchKeywords())
+                .createdAt(internalProfileEntity.getCreatedAt())
+                .lastActiveAt(internalProfileEntity.getLastActiveAt())
+                .activityFrequency(internalProfileEntity.getActivityFrequency())
+                .userTopIp(internalProfileEntity.getUserTopIp())
+                .build();
+    }
+
+    public static List<InternalProfileResponse> toResponses(List<InternalProfileEntity> internalProfileEntities) {
+        return internalProfileEntities.stream()
+                .map(InternalProfileMapper::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/InternalProfileResponse.java
@@ -1,0 +1,52 @@
+package tw.commonground.backend.service.internal.profile.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InternalProfileResponse {
+    @JsonProperty("user_id")
+    private UUID userUuid;
+
+    @Builder.Default
+    private String gender = "";
+
+    @Builder.Default
+    private String occupation = "";
+
+    @Builder.Default
+    private String location = "";
+
+    @Builder.Default
+    @JsonProperty("browsing_tags")
+    private List<String> browsingTags = Collections.emptyList();
+
+    @Builder.Default
+    @JsonProperty("search_keywords")
+    private List<String> searchKeywords = Collections.emptyList();
+
+    @Builder.Default
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt = null;
+
+    @Builder.Default
+    @JsonProperty("last_active_at")
+    private LocalDateTime lastActiveAt = null;
+
+    @Builder.Default
+    @JsonProperty("activity_frequency")
+    private Object activityFrequency = Collections.emptyMap();
+
+    @Builder.Default
+    @JsonProperty("user_top_ip")
+    private Object userTopIp = Collections.emptyMap();
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/dto/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/dto/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile.dto;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/ActivityFrequencyEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/ActivityFrequencyEntity.java
@@ -1,0 +1,20 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityFrequencyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "profile_id", nullable = false)
+    private InternalProfileEntity profile;
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileEntity.java
@@ -1,0 +1,56 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import tw.commonground.backend.service.user.entity.UserEntity;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class InternalProfileEntity {
+    @Id
+    private Long id;
+
+    private UUID uuid;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id")
+    private UserEntity user;
+
+    private String gender;
+    private String occupation;
+    private String location;
+
+    @Column(name = "browsingTags")
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> browsingTags;
+
+    @Column(name = "searchKeywords")
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> searchKeywords;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastActiveAt;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ActivityFrequencyEntity> activityFrequency;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserTopIpEntity> userTopIp;
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileRepository.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/InternalProfileRepository.java
@@ -1,0 +1,7 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InternalProfileRepository extends JpaRepository<InternalProfileEntity, Long> {
+
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/ListToStringConverter.java
@@ -1,0 +1,24 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class ListToStringConverter implements AttributeConverter<List<String>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute == null ? null : String.join(",", attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String columnValue) {
+        if (columnValue == null || columnValue.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(columnValue.split(","));
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/UserTopIpEntity.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/UserTopIpEntity.java
@@ -1,0 +1,20 @@
+package tw.commonground.backend.service.internal.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTopIpEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "profile_id", nullable = false)
+    private InternalProfileEntity profile;
+}

--- a/src/main/java/tw/commonground/backend/service/internal/profile/entity/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/entity/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile.entity;

--- a/src/main/java/tw/commonground/backend/service/internal/profile/package-info.java
+++ b/src/main/java/tw/commonground/backend/service/internal/profile/package-info.java
@@ -1,0 +1,1 @@
+package tw.commonground.backend.service.internal.profile;

--- a/src/main/java/tw/commonground/backend/service/user/UserCreatedEvent.java
+++ b/src/main/java/tw/commonground/backend/service/user/UserCreatedEvent.java
@@ -1,0 +1,16 @@
+package tw.commonground.backend.service.user;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import tw.commonground.backend.service.user.entity.UserEntity;
+
+@Getter
+public class UserCreatedEvent extends ApplicationEvent {
+
+    private final UserEntity userEntity;
+
+    public UserCreatedEvent(UserEntity userEntity) {
+        super(userEntity);
+        this.userEntity = userEntity;
+    }
+}

--- a/src/main/java/tw/commonground/backend/service/user/UserService.java
+++ b/src/main/java/tw/commonground/backend/service/user/UserService.java
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -29,6 +30,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     private final ImageService imageService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -36,9 +38,13 @@ public class UserService {
     @Value("${application.admin.email:}")
     private String adminEmail;
 
-    public UserService(UserRepository userRepository, ImageService imageService) {
+    public UserService(
+            UserRepository userRepository,
+            ImageService imageService,
+            ApplicationEventPublisher applicationEventPublisher) {
         this.userRepository = userRepository;
         this.imageService = imageService;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     public UserEntity createUser(UserInitRequest userInitRequest, UserRole role) {
@@ -54,6 +60,9 @@ public class UserService {
         }, () -> logger.info("No profile image url provided for user {}", userInitRequest.getEmail()));
 
         userRepository.save(userEntity);
+
+        applicationEventPublisher.publishEvent(new UserCreatedEvent(userEntity));
+
         return userEntity;
     }
 


### PR DESCRIPTION
Exceptions are thrown after merge commonground-project/backend#63

```

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.3.4)

2025-02-16T04:47:14.303Z  INFO 1 --- [backend] [           main] t.c.backend.BackendApplication           : Starting BackendApplication v0.0.1-SNAPSHOT using Java 21.0.6 with PID 1 (/app/app.jar started by root in /app)
2025-02-16T04:47:14.314Z  INFO 1 --- [backend] [           main] t.c.backend.BackendApplication           : No active profile set, falling back to 1 default profile: "default"
2025-02-16T04:47:16.447Z  INFO 1 --- [backend] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2025-02-16T04:47:16.759Z  INFO 1 --- [backend] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 300 ms. Found 18 JPA repository interfaces.
2025-02-16T04:47:18.632Z  INFO 1 --- [backend] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port 8080 (http)
2025-02-16T04:47:18.658Z  INFO 1 --- [backend] [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2025-02-16T04:47:18.658Z  INFO 1 --- [backend] [           main] o.apache.catalina.core.StandardEngine    : Starting Servlet engine: [Apache Tomcat/10.1.30]
2025-02-16T04:47:18.743Z  INFO 1 --- [backend] [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2025-02-16T04:47:18.746Z  INFO 1 --- [backend] [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 4351 ms
2025-02-16T04:47:19.564Z  INFO 1 --- [backend] [           main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
2025-02-16T04:47:19.675Z  INFO 1 --- [backend] [           main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.5.3.Final
2025-02-16T04:47:19.754Z  INFO 1 --- [backend] [           main] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
2025-02-16T04:47:20.341Z  INFO 1 --- [backend] [           main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
2025-02-16T04:47:20.389Z  INFO 1 --- [backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2025-02-16T04:47:20.677Z  INFO 1 --- [backend] [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@12f3fcd
2025-02-16T04:47:20.681Z  INFO 1 --- [backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2025-02-16T04:47:21.768Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000038: Composite-id class does not override equals(): tw.commonground.backend.service.issue.entity.IssueFollowKey
2025-02-16T04:47:21.768Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000039: Composite-id class does not override hashCode(): tw.commonground.backend.service.issue.entity.IssueFollowKey
2025-02-16T04:47:21.769Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000038: Composite-id class does not override equals(): tw.commonground.backend.service.reply.entity.ReplyReactionKey
2025-02-16T04:47:21.769Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000039: Composite-id class does not override hashCode(): tw.commonground.backend.service.reply.entity.ReplyReactionKey
2025-02-16T04:47:21.769Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000038: Composite-id class does not override equals(): tw.commonground.backend.service.viewpoint.entity.ViewpointReactionKey
2025-02-16T04:47:21.770Z  WARN 1 --- [backend] [           main] org.hibernate.mapping.RootClass          : HHH000039: Composite-id class does not override hashCode(): tw.commonground.backend.service.viewpoint.entity.ViewpointReactionKey
2025-02-16T04:47:23.195Z  INFO 1 --- [backend] [           main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
Hibernate: alter table if exists issue_entity alter column description set data type TEXT
Hibernate: alter table if exists issue_entity alter column insight set data type TEXT
Hibernate: alter table if exists user_entity alter column profile_image set data type bytea
Hibernate: alter table if exists viewpoint_entity alter column content set data type TEXT
2025-02-16T04:47:23.587Z  INFO 1 --- [backend] [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2025-02-16T04:47:24.268Z  INFO 1 --- [backend] [           main] o.s.d.j.r.query.QueryEnhancerFactory     : Hibernate is in classpath; If applicable, HQL parser will be used.
Hibernate: select rte1_0.id,rte1_0.expiration_time,rte1_0.is_active,rte1_0.user_id from refresh_token_entity rte1_0 where rte1_0.expiration_time<?
2025-02-16T04:47:28.076Z DEBUG 1 --- [backend] [           main] o.s.s.a.h.RoleHierarchyImpl              : buildRolesReachableInOneStepMap() - From role ROLE_ADMIN one can reach role ROLE_USER in one step.
2025-02-16T04:47:28.076Z DEBUG 1 --- [backend] [           main] o.s.s.a.h.RoleHierarchyImpl              : buildRolesReachableInOneOrMoreStepsMap() - From role ROLE_ADMIN one can reach [ROLE_USER] in one or more steps.
2025-02-16T04:47:28.245Z  WARN 1 --- [backend] [           main] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
2025-02-16T04:47:28.318Z  INFO 1 --- [backend] [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name inMemoryUserDetailsManager
2025-02-16T04:47:28.435Z  INFO 1 --- [backend] [           main] o.s.b.a.w.s.WelcomePageHandlerMapping    : Adding welcome page: class path resource [static/index.html]
2025-02-16T04:47:29.010Z  INFO 1 --- [backend] [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 2 endpoints beneath base path '/actuator'
2025-02-16T04:47:29.306Z DEBUG 1 --- [backend] [           main] o.s.s.web.DefaultSecurityFilterChain     : Will secure any request with filters: DisableEncodeUrlFilter, WebAsyncManagerIntegrationFilter, SecurityContextHolderFilter, HeaderWriterFilter, CorsFilter, LogoutFilter, OAuth2AuthorizationRequestRedirectFilter, OAuth2LoginAuthenticationFilter, TokenAuthenticationFilter, JwtAuthenticationFilter, RequestCacheAwareFilter, SecurityContextHolderAwareRequestFilter, AnonymousAuthenticationFilter, SessionManagementFilter, ExceptionTranslationFilter, AuthorizationFilter
2025-02-16T04:47:30.922Z  INFO 1 --- [backend] [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
Hibernate: select count(*) from user_entity ue1_0
Hibernate: select count(*) from internal_profile_entity ipe1_0
Hibernate: select ue1_0.id,ue1_0.email,ue1_0.nickname,ue1_0.profile_image,ue1_0.role,ue1_0.username,ue1_0.uuid from user_entity ue1_0
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select use1_0.id,use1_0.new_node_of_timeline_to_followed_issue,use1_0.new_reference_to_my_reply,use1_0.new_reply_in_my_viewpoint from user_setting_entity use1_0 where use1_0.id=?
Hibernate: select ipe1_0.id,ipe1_0.browsing_tags,ipe1_0.created_at,ipe1_0.gender,ipe1_0.last_active_at,ipe1_0.location,ipe1_0.occupation,ipe1_0.search_keywords,ipe1_0.uuid from internal_profile_entity ipe1_0 where ipe1_0.id=?
2025-02-16T04:47:31.091Z  WARN 1 --- [backend] [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.hibernate.LazyInitializationException: could not initialize proxy [tw.commonground.backend.service.user.entity.UserEntity#1] - no Session
2025-02-16T04:47:31.106Z  INFO 1 --- [backend] [           main] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2025-02-16T04:47:31.110Z  INFO 1 --- [backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2025-02-16T04:47:31.126Z  INFO 1 --- [backend] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2025-02-16T04:47:31.136Z  INFO 1 --- [backend] [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
2025-02-16T04:47:31.147Z  INFO 1 --- [backend] [           main] .s.b.a.l.ConditionEvaluationReportLogger : 

Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2025-02-16T04:47:31.172Z ERROR 1 --- [backend] [           main] o.s.boot.SpringApplication               : Application run failed

org.hibernate.LazyInitializationException: could not initialize proxy [tw.commonground.backend.service.user.entity.UserEntity#1] - no Session
	at org.hibernate.proxy.AbstractLazyInitializer.initialize(AbstractLazyInitializer.java:165) ~[hibernate-core-6.5.3.Final.jar!/:6.5.3.Final]
	at org.hibernate.proxy.AbstractLazyInitializer.getImplementation(AbstractLazyInitializer.java:314) ~[hibernate-core-6.5.3.Final.jar!/:6.5.3.Final]
	at org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor.intercept(ByteBuddyInterceptor.java:44) ~[hibernate-core-6.5.3.Final.jar!/:6.5.3.Final]
	at org.hibernate.proxy.ProxyConfiguration$InterceptorDispatcher.intercept(ProxyConfiguration.java:102) ~[hibernate-core-6.5.3.Final.jar!/:6.5.3.Final]
	at tw.commonground.backend.service.user.entity.UserEntity$HibernateProxy$AU671DFq.getUuid(Unknown Source) ~[!/:0.0.1-SNAPSHOT]
	at tw.commonground.backend.service.internal.profile.InternalProfileService.createProfile(InternalProfileService.java:65) ~[!/:0.0.1-SNAPSHOT]
	at tw.commonground.backend.service.internal.profile.InternalProfileService.lambda$onApplicationStart$4(InternalProfileService.java:103) ~[!/:0.0.1-SNAPSHOT]
	at java.base/java.util.Optional.ifPresentOrElse(Optional.java:198) ~[na:na]
	at tw.commonground.backend.service.internal.profile.InternalProfileService.onApplicationStart(InternalProfileService.java:101) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:355) ~[spring-aop-6.1.13.jar!/:6.1.13]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:716) ~[spring-aop-6.1.13.jar!/:6.1.13]
	at tw.commonground.backend.service.internal.profile.InternalProfileService$$SpringCGLIB$$0.onApplicationStart(<generated>) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.context.event.ApplicationListenerMethodAdapter.doInvoke(ApplicationListenerMethodAdapter.java:365) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.event.ApplicationListenerMethodAdapter.processEvent(ApplicationListenerMethodAdapter.java:237) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.event.ApplicationListenerMethodAdapter.onApplicationEvent(ApplicationListenerMethodAdapter.java:168) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:185) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:178) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:156) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:452) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:385) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:993) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:628) ~[spring-context-6.1.13.jar!/:6.1.13]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:335) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1363) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1352) ~[spring-boot-3.3.4.jar!/:3.3.4]
	at tw.commonground.backend.BackendApplication.main(BackendApplication.java:15) ~[!/:0.0.1-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:102) ~[app.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.launch.Launcher.launch(Launcher.java:64) ~[app.jar:0.0.1-SNAPSHOT]
	at org.springframework.boot.loader.launch.JarLauncher.main(JarLauncher.java:40) ~[app.jar:0.0.1-SNAPSHOT]

```