### PR TITLE
Prevent null pointer exception when accessing replies without login

### DIFF
--- a/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
+++ b/src/main/java/tw/commonground/backend/service/reply/ReplyController.java
@@ -49,7 +49,11 @@ public class ReplyController {
         Pageable pageable = paginationParser.parsePageable(paginationRequest);
         Page<ReplyEntity> pageReplies = replyService.getViewpointReplies(id, pageable);
 
-        return ResponseEntity.ok(getPaginationResponse(user.getId(), pageReplies));
+        if (user == null) {
+            return ResponseEntity.ok(getPaginationResponse(null, pageReplies));
+        } else {
+            return ResponseEntity.ok(getPaginationResponse(user.getId(), pageReplies));
+        }
     }
 
     @PostMapping("/viewpoint/{id}/replies")


### PR DESCRIPTION
## Type of changes
- Fix

## Purpose
Fixed an issue where accessing replies under a viewpoint without logging in would cause a NullPointerException.